### PR TITLE
Fix crash on bot_nav_save

### DIFF
--- a/regamedll/dlls/bot/cs_bot_manager.cpp
+++ b/regamedll/dlls/bot/cs_bot_manager.cpp
@@ -622,8 +622,7 @@ void CCSBotManager::__MAKE_VHOOK(ServerCommand)(const char *pcmd)
 	else if (FStrEq(pcmd, "bot_nav_save"))
 	{
 		GET_GAME_DIR(buffer);
-		buffer[ Q_strlen(buffer) ] = '\\';
-
+		Q_strcat(buffer, "\\");
 		Q_strcat(buffer, CBotManager::GetNavMapFilename());
 
 		if (SaveNavigationMap(buffer))


### PR DESCRIPTION
Fixes incorrectly terminated string caused by appending backslash.