### PR TITLE
Fix crash when custom SV_StudioSetupBones exported to the engine

### DIFF
--- a/regamedll/dlls/animation.cpp
+++ b/regamedll/dlls/animation.cpp
@@ -1062,16 +1062,8 @@ void SV_StudioSetupBones(model_t *pModel, float frame, int sequence, const vec_t
 		/*static */float q3[MAXSTUDIOBONES][4], q4[MAXSTUDIOBONES][4];
 
 		float_precision s, t;
-		if( pEdict )
-		{
-			s = GetPlayerYaw(pEdict);
-			t = GetPlayerPitch(pEdict);
-		}
-		else
-		{
-			s = t = 0.0f;	
-		}
-		
+		s = GetPlayerYaw(pEdict);
+		t = GetPlayerPitch(pEdict);
 
 		// Blending is 0-127 == Left to Middle, 128 to 255 == Middle to right
 		if (s <= 127.0f)

--- a/regamedll/dlls/animation.cpp
+++ b/regamedll/dlls/animation.cpp
@@ -1062,9 +1062,16 @@ void SV_StudioSetupBones(model_t *pModel, float frame, int sequence, const vec_t
 		/*static */float q3[MAXSTUDIOBONES][4], q4[MAXSTUDIOBONES][4];
 
 		float_precision s, t;
-
-		s = GetPlayerYaw(pEdict);
-		t = GetPlayerPitch(pEdict);
+		if( pEdict )
+		{
+			s = GetPlayerYaw(pEdict);
+			t = GetPlayerPitch(pEdict);
+		}
+		else
+		{
+			s = t = 0.0f;	
+		}
+		
 
 		// Blending is 0-127 == Left to Middle, 128 to 255 == Middle to right
 		if (s <= 127.0f)

--- a/regamedll/dlls/player.cpp
+++ b/regamedll/dlls/player.cpp
@@ -8030,6 +8030,9 @@ void CBasePlayer::ResetStamina()
 
 float_precision GetPlayerPitch(const edict_t *pEdict)
 {
+	if( !pEdict )
+		return 0.0f;
+	
 	entvars_t *pev = VARS(const_cast<edict_t *>(pEdict));
 	CBasePlayer *pPlayer = dynamic_cast<CBasePlayer *>(CBasePlayer::Instance(pev));
 
@@ -8041,6 +8044,9 @@ float_precision GetPlayerPitch(const edict_t *pEdict)
 
 float_precision GetPlayerYaw(const edict_t *pEdict)
 {
+	if( !pEdict )
+		return 0.0f;
+	
 	entvars_t *pev = VARS(const_cast<edict_t *>(pEdict));
 	CBasePlayer *pPlayer = dynamic_cast<CBasePlayer *>(CBasePlayer::Instance(pev));
 


### PR DESCRIPTION
This fixes crash, in case ReGameDLL_CS running with a local client. 

If local client do a tracing for studio models, it calls SV_StudioSetuoBones with a NULL pEdict. So it must be checked before we call GetPlayerYaw/Pitch to prevent crash.