### PR TITLE
Added mp_disable_buyzone cvar

### DIFF
--- a/regamedll/dlls/game.cpp
+++ b/regamedll/dlls/game.cpp
@@ -116,6 +116,7 @@ cvar_t showtriggers = { "showtriggers", "0", 0, 0.0f, nullptr };				// debug cva
 cvar_t hostagehurtable = { "mp_hostage_hurtable", "1", FCVAR_SERVER, 0.0f, nullptr };
 cvar_t roundover = { "mp_roundover", "0", FCVAR_SERVER, 0.0f, nullptr };
 cvar_t forcerespawn = { "mp_forcerespawn", "0", FCVAR_SERVER, 0.0f, nullptr };
+cvar_t disablebuyzone = { "mp_disable_buyzone", "0", FCVAR_SERVER, 0.0f, nullptr };
 
 void GameDLL_Version_f()
 {
@@ -262,6 +263,7 @@ void EXT_FUNC GameDLLInit()
 	CVAR_REGISTER(&hostagehurtable);
 	CVAR_REGISTER(&roundover);
 	CVAR_REGISTER(&forcerespawn);
+	CVAR_REGISTER(&disablebuyzone);
 
 	// print version
 	CONSOLE_ECHO("ReGameDLL version: " APP_VERSION "\n");

--- a/regamedll/dlls/game.h
+++ b/regamedll/dlls/game.h
@@ -149,6 +149,7 @@ extern cvar_t showtriggers;
 extern cvar_t hostagehurtable;
 extern cvar_t roundover;
 extern cvar_t forcerespawn;
+extern cvar_t disablebuyzone;
 
 #endif
 

--- a/regamedll/dlls/player.cpp
+++ b/regamedll/dlls/player.cpp
@@ -6360,8 +6360,13 @@ void CBasePlayer::HandleSignals()
 {
 	if (CSGameRules()->IsMultiplayer())
 	{
-		if (!CSGameRules()->m_bMapHasBuyZone)
-			OLD_CheckBuyZone(this);
+#ifdef REGAMEDLL_ADD
+		if( disablebuyzone.value != 1.0f)
+#endif
+		{
+			if (!CSGameRules()->m_bMapHasBuyZone)
+				OLD_CheckBuyZone(this);
+		}
 
 		if (!CSGameRules()->m_bMapHasBombZone)
 			OLD_CheckBombTarget(this);

--- a/regamedll/dlls/triggers.cpp
+++ b/regamedll/dlls/triggers.cpp
@@ -1750,6 +1750,11 @@ void CBombTarget::__MAKE_VHOOK(Spawn)()
 
 void CBombTarget::BombTargetTouch(CBaseEntity *pOther)
 {
+#ifdef REGAMEDLL_ADD
+ 	if( disablebuyzone.value == 1.0f)
+		return;
+#endif
+	
 	if (!pOther->IsPlayer())
 		return;
 

--- a/regamedll/dlls/triggers.cpp
+++ b/regamedll/dlls/triggers.cpp
@@ -1727,6 +1727,11 @@ void CBuyZone::__MAKE_VHOOK(Spawn)()
 
 void CBuyZone::BuyTouch(CBaseEntity *pOther)
 {
+#ifdef REGAMEDLL_ADD
+ 	if( disablebuyzone.value == 1.0f)
+		return;
+#endif	
+	
 	if (!pOther->IsPlayer())
 		return;
 
@@ -1750,11 +1755,6 @@ void CBombTarget::__MAKE_VHOOK(Spawn)()
 
 void CBombTarget::BombTargetTouch(CBaseEntity *pOther)
 {
-#ifdef REGAMEDLL_ADD
- 	if( disablebuyzone.value == 1.0f)
-		return;
-#endif
-	
 	if (!pOther->IsPlayer())
 		return;
 


### PR DESCRIPTION
usefull for many gamemods jailbreak/zombie/deathmatch, mp_disable_buyzone 1/0 by default its set to 0 can be enabled/disabled in-game.