### PR TITLE
completly disable buyzone when mp_buytime is 0

### DIFF
--- a/regamedll/dlls/player.cpp
+++ b/regamedll/dlls/player.cpp
@@ -6375,8 +6375,14 @@ void CBasePlayer::HandleSignals()
 {
 	if (CSGameRules()->IsMultiplayer())
 	{
-		if (!CSGameRules()->m_bMapHasBuyZone)
-			OLD_CheckBuyZone(this);
+		
+#ifdef REGAMEDLL_ADD
+		if (buytime.value != 0.0f)
+#endif
+		{			
+			if (!CSGameRules()->m_bMapHasBuyZone)
+				OLD_CheckBuyZone(this);
+		}
 
 		if (!CSGameRules()->m_bMapHasBombZone)
 			OLD_CheckBombTarget(this);

--- a/regamedll/dlls/triggers.cpp
+++ b/regamedll/dlls/triggers.cpp
@@ -1727,6 +1727,11 @@ void CBuyZone::__MAKE_VHOOK(Spawn)()
 
 void CBuyZone::BuyTouch(CBaseEntity *pOther)
 {
+#ifdef REGAMEDLL_ADD
+	if( buytime.value == 0.0f)
+		return;
+#endif	
+	
 	if (!pOther->IsPlayer())
 		return;
 

--- a/regamedll/dlls/triggers.cpp
+++ b/regamedll/dlls/triggers.cpp
@@ -1728,7 +1728,7 @@ void CBuyZone::__MAKE_VHOOK(Spawn)()
 void CBuyZone::BuyTouch(CBaseEntity *pOther)
 {
 #ifdef REGAMEDLL_ADD
-	if( buytime.value == 0.0f)
+	if (buytime.value == 0.0f)
 		return;
 #endif	
 	


### PR DESCRIPTION
currently when you set mp_buytime 0 it shows buyicon and its allows you to open weapons menu and when you try buy somthing it show "0 seconds passed since..." now with this patch no icon will be shown and menu will not open.