### PR TITLE
Round restart delay.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Archive's bin directory contains 2 subdirectories, 'bugfixed' and 'pure'
 | mp_maxmoney                   | 16000   | 0   | `0x7FFFFFFF` | The maximum allowable amount of money in the game |
 | mp_round_infinite             | 0       | 0   | 1            | Flags for fine grained control (choose as many as needed)<br/>`0` disabled<br/>`1` enabled<br/><br/>or flags<br/>`a` block round time round end check<br/>`b` block needed players round end check<br/>`c` block VIP assassination/success round end check<br/>`d` block prison escape round end check<br/>`e` block bomb round end check<br/>`f` block team extermination round end check<br/>`g` block hostage rescue round end check<br/><br/>`Example setting:` "ae" blocks round time and bomb round end checks |
 | mp_roundover                  | 0       | -   | -            | The round by expired time will be over, if on a map it does not have the scenario of the game.<br/>`0` disabled<br/>`1` enabled |
-| mp_restart_round_delay        | 5       | -   | -            | Number of seconds to delay before restarting a round after a win. |
+| mp_round_restart_delay        | 5       | -   | -            | Number of seconds to delay before restarting a round after a win. |
 | mp_hegrenade_penetration      | 0       | 0   | 1            | Disable grenade damage through walls.<br/>`0` disabled<br/>`1` enabled |
 | mp_nadedrops                  | 0       | 0   | 2            | Drop a grenade after player death.<br/>`0` disabled<br/>`1` drop one the grenade<br/>`2` drop an everyone grenades |
 | mp_roundrespawn_time          | 20      | 0   | -            | Player cannot respawn until next round if more than N seconds has elapsed since the beginning round |

--- a/dist/game.cfg
+++ b/dist/game.cfg
@@ -53,7 +53,7 @@ mp_roundover 0
 
 // Number of seconds to delay before restarting a round after a win.
 // Default value: "5"
-mp_restart_round_delay 5
+mp_round_restart_delay 5
 
 // Disable grenade damage through walls
 // 0 - disabled


### PR DESCRIPTION
Source code says to use "mp_round_restart_delay" FCVAR but it in the doc it was inverted to "mp_restart_round_delay" so just replaced and fixed it.