### PR TITLE
Add more sv_alltalk modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Archive's bin directory contains 2 subdirectories, 'bugfixed' and 'pure'
 | mp_timelimit                  | 0       | -   | -            | Period between map rotations.<br />`0` means no limit |
 | mp_forcerespawn               | 0       | 0   | -            | Players will automatically respawn when killed.<br/>`0` disabled<br/>`>0.00001` time delay to respawn |
 | mp_hostage_hurtable           | 1       | 0   | 1            | The hostages can take the damage.<br/>`0` disabled<br/>`1` enabled |
+| sv_alltalk             | 0       | 0   | 3            | When teammates can hear each other.<br/>`0` dead don't hear alive<br/>`1` no restrictions<br/>`2` teammates hear each other<br/>`3` Same as 2, but spectators hear everybody
 | showtriggers                  | 0       | 0   | 1            | Debug cvar shows triggers. |
 | bot_deathmatch                | 0       | 0   | 1            | Set's the mode for the zBot.<br/>`0` disabled<br/>`1` enable mode Deathmatch and not allow to do the scenario |
 | bot_quota_mode                | normal  | -   | -            | Determines the type of quota.<br/>`normal` default behaviour<br/>`fill` the server will adjust bots to keep `N` players in the game, where `N` is bot_quota |

--- a/regamedll/game_shared/voice_gamemgr.cpp
+++ b/regamedll/game_shared/voice_gamemgr.cpp
@@ -160,8 +160,6 @@ void CVoiceGameMgr::UpdateMasks()
 {
 	m_UpdateInterval = 0;
 
-	bool bAllTalk = !!(sv_alltalk.value);
-
 	for (int iClient = 0; iClient < m_nMaxPlayers; ++iClient)
 	{
 		CBaseEntity *pEnt = UTIL_PlayerByIndex(iClient + 1);
@@ -188,11 +186,28 @@ void CVoiceGameMgr::UpdateMasks()
 			// Build a mask of who they can hear based on the game rules.
 			for (int iOtherClient = 0; iOtherClient < m_nMaxPlayers; ++iOtherClient)
 			{
-				CBaseEntity *pEnt = UTIL_PlayerByIndex(iOtherClient + 1);
+				auto *pOtherPlayer = (CBasePlayer *) UTIL_PlayerByIndex(iOtherClient + 1);
 
-				if (pEnt && (bAllTalk || m_pHelper->CanPlayerHearPlayer(pPlayer, (CBasePlayer *)pEnt)))
+				if (!pOtherPlayer)
+					continue;
+
+				switch((int)sv_alltalk.value)
 				{
-					gameRulesMask[ iOtherClient ] = true;
+					case 0:
+						gameRulesMask[ iOtherClient ] = m_pHelper->CanPlayerHearPlayer(pPlayer, pOtherPlayer);
+						break;
+					case 1:
+						gameRulesMask[ iOtherClient ] = true;
+						break;
+					case 2:
+						gameRulesMask[ iOtherClient ] = pPlayer->m_iTeam == pOtherPlayer->m_iTeam;
+						break;
+					case 3:
+						gameRulesMask[ iOtherClient ] = pPlayer->m_iTeam == pOtherPlayer->m_iTeam || pPlayer->IsObserver();
+						break;
+					default:
+						gameRulesMask[ iOtherClient ] = true; // HLDS Behavior
+						break;
 				}
 			}
 		}

--- a/regamedll/game_shared/voice_gamemgr.cpp
+++ b/regamedll/game_shared/voice_gamemgr.cpp
@@ -186,28 +186,27 @@ void CVoiceGameMgr::UpdateMasks()
 			// Build a mask of who they can hear based on the game rules.
 			for (int iOtherClient = 0; iOtherClient < m_nMaxPlayers; ++iOtherClient)
 			{
-				auto *pOtherPlayer = (CBasePlayer *) UTIL_PlayerByIndex(iOtherClient + 1);
+				auto *pOtherPlayer = UTIL_PlayerByIndex(iOtherClient + 1);
 
 				if (!pOtherPlayer)
 					continue;
 
-				switch((int)sv_alltalk.value)
+				switch ((int)sv_alltalk.value)
 				{
-					case 0:
-						gameRulesMask[ iOtherClient ] = m_pHelper->CanPlayerHearPlayer(pPlayer, pOtherPlayer);
-						break;
-					case 1:
-						gameRulesMask[ iOtherClient ] = true;
-						break;
-					case 2:
-						gameRulesMask[ iOtherClient ] = pPlayer->m_iTeam == pOtherPlayer->m_iTeam;
-						break;
-					case 3:
-						gameRulesMask[ iOtherClient ] = pPlayer->m_iTeam == pOtherPlayer->m_iTeam || pPlayer->IsObserver();
-						break;
-					default:
-						gameRulesMask[ iOtherClient ] = true; // HLDS Behavior
-						break;
+				case 0:
+					gameRulesMask[ iOtherClient ] = m_pHelper->CanPlayerHearPlayer(pPlayer, pOtherPlayer);
+					break;
+#ifdef REGAMEDLL_ADD
+				case 2:
+					gameRulesMask[ iOtherClient ] = pPlayer->m_iTeam == pOtherPlayer->m_iTeam;
+					break;
+				case 3:
+					gameRulesMask[ iOtherClient ] = pPlayer->m_iTeam == pOtherPlayer->m_iTeam || pPlayer->IsObserver();
+					break;
+#endif
+				default:
+					gameRulesMask[ iOtherClient ] = true; // HLDS Behavior
+					break;
 				}
 			}
 		}


### PR DESCRIPTION
### New modes:

2. The teammates hear each other (dead hear alive vise versa)
3. Same as 2, but spectators hear everybody.

This PR will get good use in Clan War servers.
Idea was suggested by N3UR0.