### PR TITLE
Fixed GetHullBounds

### DIFF
--- a/regamedll/dlls/client.cpp
+++ b/regamedll/dlls/client.cpp
@@ -4601,9 +4601,46 @@ int EXT_FUNC ConnectionlessPacket(const struct netadr_s *net_from, const char *a
 	return 0;
 }
 
+// TODO: int -> qboolean or enum
 int EXT_FUNC GetHullBounds(int hullnumber, float *mins, float *maxs)
 {
-	return hullnumber < 3;
+#ifdef REGAMEDLL_FIXES
+	switch (hullnumber)
+	{
+	case 0: // Normal player
+		Q_memcpy(mins, (float*)VEC_HULL_MIN, sizeof(vec3_t));
+		Q_memcpy(maxs, (float*)VEC_HULL_MAX, sizeof(vec3_t));
+		return TRUE;
+	case 1: // Crouched player
+		Q_memcpy(mins, (float*)VEC_DUCK_HULL_MIN, sizeof(vec3_t));
+		Q_memcpy(maxs, (float*)VEC_DUCK_HULL_MAX, sizeof(vec3_t));
+		return TRUE;
+	case 2: // Point based hull
+		Q_memcpy(mins, (float*)Vector(0, 0, 0), sizeof(vec3_t));
+		Q_memcpy(maxs, (float*)Vector(0, 0, 0), sizeof(vec3_t));
+		return TRUE;
+	default:
+		return FALSE;
+	}
+#else // REGAMEDLL_FIXES
+	switch (hullnumber)
+	{
+	case 0: // Normal player
+		mins = VEC_HULL_MIN;
+		maxs = VEC_HULL_MAX;
+		return TRUE;
+	case 1: // Crouched player
+		mins = VEC_DUCK_HULL_MIN;
+		maxs = VEC_DUCK_HULL_MAX;
+		return TRUE;
+	case 2: // Point based hull
+		mins = Vector(0, 0, 0);
+		maxs = Vector(0, 0, 0);
+		return TRUE;
+	default:
+		return FALSE;
+	}
+#endif // REGAMEDLL_FIXES
 }
 
 // Create pseudo-baselines for items that aren't placed in the map at spawn time, but which are likely


### PR DESCRIPTION
Motivated by https://github.com/ValveSoftware/halflife/pull/1717.
This also fixes a bug with roof boost glitch (idk how to name it properly, I found it [here](https://forums.alliedmods.net/showthread.php?t=81877)). Video with demonstration https://youtu.be/9zkamv8shqM?t=7m55s from [here](https://forums.alliedmods.net/showthread.php?t=287955).
There is also [info](https://gist.github.com/WPMGPRoSToTeMa/2e6e0454654f9e4ca22ee3e987051b57) about `HUD_GetHullBounds` patching for the client. (this fixes twitching when you staying above crouching player https://youtu.be/0BUMoGDitVU)