### PR TITLE
Fixed bug with lastinv (fix from 7561)

### DIFF
--- a/regamedll/dlls/player.cpp
+++ b/regamedll/dlls/player.cpp
@@ -6536,7 +6536,10 @@ BOOL EXT_FUNC CBasePlayer::__API_HOOK(RemovePlayerItem)(CBasePlayerItem *pItem)
 		pev->viewmodel = 0;
 		pev->weaponmodel = 0;
 	}
-	else if (m_pLastItem == pItem)
+#ifndef REGAMEDLL_FIXES
+	else
+#endif
+	if (m_pLastItem == pItem)
 		m_pLastItem = NULL;
 
 	CBasePlayerItem *pPrev = m_rgpPlayerItems[pItem->iItemSlot()];


### PR DESCRIPTION
Originally reported [here](https://github.com/ValveSoftware/halflife/issues/1815).
This bug is not reproducable in CS by default. To reproduce it you can enable knife drop, then use this command sequence `drop weapon_knife;drop;lastinv`.