### PR TITLE
Prevent kevlar.wav from overwriting gunpickup2.wav sound

### DIFF
--- a/regamedll/dlls/client.cpp
+++ b/regamedll/dlls/client.cpp
@@ -1219,7 +1219,11 @@ void BuyItem(CBasePlayer *pPlayer, int iSlot)
 				pPlayer->pev->body = 1;
 				pPlayer->AddAccount(-DEFUSEKIT_PRICE, RT_PLAYER_BOUGHT_SOMETHING);
 
+#ifdef REGAMEDLL_FIXES
+				EMIT_SOUND(ENT(pPlayer->pev), CHAN_VOICE, "items/kevlar.wav", VOL_NORM, ATTN_NORM);
+#else
 				EMIT_SOUND(ENT(pPlayer->pev), CHAN_ITEM, "items/kevlar.wav", VOL_NORM, ATTN_NORM);
+#endif
 				pPlayer->SendItemStatus();
 			}
 			break;


### PR DESCRIPTION
kevlar.wav is empty sound, but I guess this should be fine
Credits: @Vaqtincha for bug report (24 in #185)