### PR TITLE
Fix dead defuser progress bar issues

### DIFF
--- a/regamedll/dlls/ggrenade.cpp
+++ b/regamedll/dlls/ggrenade.cpp
@@ -1358,6 +1358,10 @@ void CGrenade::C4Think()
 			m_bStartDefuse = false;
 			m_pBombDefuser = NULL;
 
+#ifdef REGAMEDLL_FIXES
+			pPlayer->SetProgressBarTime(0);			
+#endif
+
 			// tell the bots someone has aborted defusing
 			if (TheBots)
 			{


### PR DESCRIPTION
I wasn't able to reproduce bugs  5 and 6 in #185, but I guess it's possible, so better to cancel progress bar when defuser dies.