### PR TITLE
Remove useless code from CC4::Use

### DIFF
--- a/regamedll/dlls/wpn_shared/wpn_c4.cpp
+++ b/regamedll/dlls/wpn_shared/wpn_c4.cpp
@@ -313,6 +313,7 @@ void CC4::KeyValue(KeyValueData *pkvd)
 
 void CC4::Use(CBaseEntity *pActivator, CBaseEntity *pCaller, USE_TYPE useType, float value)
 {
+#ifndef REGAMEDLL_FIXES
 	if (m_pPlayer)
 		return;
 
@@ -345,6 +346,7 @@ void CC4::Use(CBaseEntity *pActivator, CBaseEntity *pCaller, USE_TYPE useType, f
 		pPlayer->m_pentCurBombTarget = m_pentOldCurBombTarget;
 		SUB_Remove();
 	}
+#endif
 }
 
 float CC4::GetMaxSpeed()


### PR DESCRIPTION
It is actually related to CS 1.3 training room: https://www.youtube.com/watch?v=cqGrnXFX8Vk