### PR TITLE
Increase NEXT_DEFUSE_TIME.

### DIFF
--- a/regamedll/dlls/ggrenade.cpp
+++ b/regamedll/dlls/ggrenade.cpp
@@ -938,7 +938,7 @@ CGrenade *CGrenade::ShootTimed(entvars_t *pevOwner, Vector vecStart, Vector vecV
 }
 
 #ifdef REGAMEDLL_FIXES
-	constexpr float NEXT_DEFUSE_TIME = 0.033f;
+	constexpr float NEXT_DEFUSE_TIME = 0.25f;
 #else
 	constexpr float NEXT_DEFUSE_TIME = 0.5f;
 #endif


### PR DESCRIPTION
This should make it safer to defuse in low framerate, but make defuse check 2 time more responsible