### PR TITLE
Adjust bomb angles for righthanded users (resolves #218)

### DIFF
--- a/regamedll/dlls/wpn_shared/wpn_c4.cpp
+++ b/regamedll/dlls/wpn_shared/wpn_c4.cpp
@@ -160,7 +160,7 @@ void CC4::PrimaryAttack()
 					}
 
 #ifdef REGAMEDLL_FIXES
-					Vector vBombAngles = Vector(0, m_pPlayer->pev->angles[1] + 90.0, 0);
+					Vector vBombAngles = Vector(0, m_pPlayer->pev->angles[1] - 90.0, 0);
 #else
 					Vector vBombAngles = Vector(0, 0, 0);
 #endif


### PR DESCRIPTION
Since `cl_righthand 1` is the most popular option we must adjust ourselves for it (look for the wires after the bomb is planted).