### PR TITLE
Remove rendering from spawn protection.

### DIFF
--- a/regamedll/dlls/player.cpp
+++ b/regamedll/dlls/player.cpp
@@ -9529,9 +9529,6 @@ LINK_HOOK_CLASS_VOID_CHAIN(CBasePlayer, SetSpawnProtection, (float flProtectionT
 void EXT_FUNC CBasePlayer::__API_HOOK(SetSpawnProtection)(float flProtectionTime)
 {
 	pev->takedamage = DAMAGE_NO;
-	pev->rendermode = kRenderTransAdd;
-	pev->renderamt = 100.0;
-
 	CSPlayer()->m_flSpawnProtectionEndTime = gpGlobals->time + flProtectionTime;
 }
 
@@ -9540,7 +9537,5 @@ LINK_HOOK_CLASS_VOID_CHAIN2(CBasePlayer, RemoveSpawnProtection)
 void CBasePlayer::__API_HOOK(RemoveSpawnProtection)()
 {
 	pev->takedamage = DAMAGE_AIM;
-	pev->rendermode = kRenderNormal;
-
 	CSPlayer()->m_flSpawnProtectionEndTime = 0.0f;
 }


### PR DESCRIPTION
Related to #266

> Actually the render effect is not needed at all, you just ruin 3rd-party rendering mod. Make spawn protection is enough. As far as i know HLDM don't have render effect too.

I agree with @lespaul64, because render effect is now uncustomizable and mod-breaking. It feels ideologically bad.

I think it's better to receive some community feedback until doing the final decision
@wopox1337 @WPMGPRoSToTeMa @s1lentq 