### PR TITLE
Fix bug, mp_fraglimit is less than zero

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Archive's bin directory contains 2 subdirectories, 'bugfixed' and 'pure'
 | mp_auto_join_team             | 0       | 0   | 1            | Automatically joins the team.<br/>`0` disabled<br/>`1` enable (Use in conjunction with the cvar humans_join_team any/CT/T) |
 | mp_max_teamkills              | 3       | 0   | -            | Maximum number of allowed teamkills before autokick. Used when enabled mp_autokick. |
 | mp_fragsleft                  | -       | -   | -            | Is the number of frags left, if you have set mp_fraglimit. You just type mp_fragsleft in server console, and it tells you the number of frags left depending of mp_fraglimit. |
-| mp_fraglimit                  | 0       | -   | -            | If set to something other than 0, when anybody’s scored reaches mp_fraglimit the server changes map.<br />`0` means no limit |
+| mp_fraglimit                  | 0       | 0   | -            | If set to something other than 0, when anybody’s scored reaches mp_fraglimit the server changes map.<br />`0` means no limit |
 | mp_timeleft                   | -       | -   | -            | Is the number of time left before the map changes, if you have set mp_timelimit. You just type mp_timeleft in server console, and it tells you the number of time left depending of mp_timelimit. |
 | mp_timelimit                  | 0       | -   | -            | Period between map rotations.<br />`0` means no limit |
 | mp_forcerespawn               | 0       | 0   | -            | Players will automatically respawn when killed.<br/>`0` disabled<br/>`>0.00001` time delay to respawn |

--- a/regamedll/dlls/multiplay_gamerules.cpp
+++ b/regamedll/dlls/multiplay_gamerules.cpp
@@ -2607,7 +2607,7 @@ bool CHalfLifeMultiplay::CheckFragLimit()
 #ifdef REGAMEDLL_ADD
 	int fragsRemaining = 0;
 
-	if (fraglimit.value)
+	if (fraglimit.value > 0)
 	{
 		int bestFrags = fraglimit.value;
 

--- a/regamedll/dlls/multiplay_gamerules.cpp
+++ b/regamedll/dlls/multiplay_gamerules.cpp
@@ -2607,7 +2607,7 @@ bool CHalfLifeMultiplay::CheckFragLimit()
 #ifdef REGAMEDLL_ADD
 	int fragsRemaining = 0;
 
-	if (fraglimit.value > 0)
+	if (fraglimit.value >= 0)
 	{
 		int bestFrags = fraglimit.value;
 


### PR DESCRIPTION
Why?
BUG: When user set mp_fraglimit < 0 - server will reboot every map when server have players.