### PR TITLE
Do not ignore thirdparty bots in humans_join_team cvar checks.

### DIFF
--- a/regamedll/dlls/client.cpp
+++ b/regamedll/dlls/client.cpp
@@ -1904,7 +1904,7 @@ BOOL EXT_FUNC __API_HOOK(HandleMenu_ChooseTeam)(CBasePlayer *pPlayer, int slot)
 
 	if (team != SPECTATOR && !pPlayer->IsBot()
 #ifdef REGAMEDLL_ADD
-		&& auto_join_team.value != 1.0f
+		&& !(pPlayer->pev->flags & FL_FAKECLIENT) && auto_join_team.value != 1.0f
 #endif
 	)
 	{

--- a/regamedll/dlls/multiplay_gamerules.cpp
+++ b/regamedll/dlls/multiplay_gamerules.cpp
@@ -3587,7 +3587,11 @@ void CHalfLifeMultiplay::PlayerThink(CBasePlayer *pPlayer)
 		pPlayer->m_iMenu = Menu_ChooseTeam;
 		pPlayer->m_iJoiningState = PICKINGTEAM;
 
-		if (slot != MENU_SLOT_TEAM_UNDEFINED && !pPlayer->IsBot())
+		if (slot != MENU_SLOT_TEAM_UNDEFINED && !pPlayer->IsBot()
+#ifdef REGAMEDLL_ADD
+			&& !(pPlayer->pev->flags & FL_FAKECLIENT)
+#endif
+			)
 		{
 #ifdef REGAMEDLL_ADD
 			m_bSkipShowMenu = (auto_join_team.value != 0.0f) && !(pPlayer->pev->flags & FL_FAKECLIENT);


### PR DESCRIPTION
Game dll considers third party bots as humans when dealing with humans_join_team cvar, thus making those bots to join team specified in this cvar.