### PR TITLE
Add CanHolster check

### DIFF
--- a/regamedll/dlls/player.cpp
+++ b/regamedll/dlls/player.cpp
@@ -5570,7 +5570,7 @@ NOXREF void CBasePlayer::SelectNextItem(int iItem)
 {
 	CBasePlayerItem *pItem = m_rgpPlayerItems[iItem];
 
-	if (!pItem)
+	if (!pItem || m_pActiveItem && !m_pActiveItem->CanHolster())
 	{
 		return;
 	}
@@ -5627,7 +5627,7 @@ void CBasePlayer::SelectItem(const char *pstr)
 	}
 
 	auto pItem = GetItemByName(pstr);
-	if (!pItem || pItem == m_pActiveItem)
+	if (!pItem || pItem == m_pActiveItem || m_pActiveItem && !m_pActiveItem->CanHolster())
 		return;
 
 	ResetAutoaim();

--- a/regamedll/dlls/player.cpp
+++ b/regamedll/dlls/player.cpp
@@ -5568,9 +5568,12 @@ void CBasePlayer::Reset()
 
 NOXREF void CBasePlayer::SelectNextItem(int iItem)
 {
+	if (m_pActiveItem && !m_pActiveItem->CanHolster())
+		return;
+	
 	CBasePlayerItem *pItem = m_rgpPlayerItems[iItem];
 
-	if (!pItem || m_pActiveItem && !m_pActiveItem->CanHolster())
+	if (!pItem)
 	{
 		return;
 	}
@@ -5621,13 +5624,16 @@ NOXREF void CBasePlayer::SelectNextItem(int iItem)
 
 void CBasePlayer::SelectItem(const char *pstr)
 {
+	if (m_pActiveItem && !m_pActiveItem->CanHolster())
+		return;
+
 	if (!pstr)
 	{
 		return;
 	}
 
 	auto pItem = GetItemByName(pstr);
-	if (!pItem || pItem == m_pActiveItem || m_pActiveItem && !m_pActiveItem->CanHolster())
+	if (!pItem || pItem == m_pActiveItem)
 		return;
 
 	ResetAutoaim();


### PR DESCRIPTION
Hello, just a little addition so player won't switch weapon if active item can't be holstered.