### PR TITLE
Add a replacement for prediction removal

### DIFF
--- a/regamedll/dlls/wpn_shared/wpn_ak47.cpp
+++ b/regamedll/dlls/wpn_shared/wpn_ak47.cpp
@@ -138,9 +138,6 @@ void CAK47::AK47Fire(float flSpread, float flCycleTime, BOOL fUseAutoAim)
 	flag = 0;
 #endif
 
-	PLAYBACK_EVENT_FULL(flag, m_pPlayer->edict(), m_usFireAK47, 0, (float *)&g_vecZero, (float *)&g_vecZero, vecDir.x, vecDir.y,
-		int(m_pPlayer->pev->punchangle.x * 100), int(m_pPlayer->pev->punchangle.y * 100), FALSE, FALSE);
-
 	m_pPlayer->m_iWeaponVolume = NORMAL_GUN_VOLUME;
 	m_pPlayer->m_iWeaponFlash = BRIGHT_GUN_FLASH;
 


### PR DESCRIPTION
Hello, to alter weapon fire sound we have to remove weapon prediction as this code does https://forums.alliedmods.net/showpost.php?p=2543935&postcount=31, but this also results in removal of bullet holes with smokes and weapon fire animation, beyond of slightly increase ping of players.

I believe there's a more appropriate way of do this, that would be cancel the call of PLAYBACK_EVENT_FULL, although it also results in removal of bullet holes and probably weapon fire animation.

We could add a member "m_bCantPredict" or something like. I did this branch for test purpose. If the method work, I'll proceed with the addition of this member.