### PR TITLE
Implement RG_CBasePlayer_DropIdlePlayer hook

### DIFF
--- a/regamedll/dlls/API/CAPI_Impl.cpp
+++ b/regamedll/dlls/API/CAPI_Impl.cpp
@@ -162,6 +162,7 @@ GAMEHOOK_REGISTRY(CBasePlayer_RemoveSpawnProtection);
 GAMEHOOK_REGISTRY(IsPenetrableEntity);
 GAMEHOOK_REGISTRY(CBasePlayer_HintMessageEx);
 GAMEHOOK_REGISTRY(CBasePlayer_UseEmpty);
+GAMEHOOK_REGISTRY(CBasePlayer_DropIdlePlayer);
 
 int CReGameApi::GetMajorVersion() {
 	return REGAMEDLL_API_VERSION_MAJOR;

--- a/regamedll/dlls/API/CAPI_Impl.h
+++ b/regamedll/dlls/API/CAPI_Impl.h
@@ -541,6 +541,10 @@ typedef IHookChainRegistryClassImpl<bool, CBasePlayer, const char *, float, bool
 typedef IHookChainClassImpl<void, CBasePlayer> CReGameHook_CBasePlayer_UseEmpty;
 typedef IHookChainRegistryClassImpl<void, CBasePlayer> CReGameHookRegistry_CBasePlayer_UseEmpty;
 
+// CBasePlayer::DropIdlePlayer hook
+typedef IHookChainClassImpl<void, CBasePlayer> CReGameHook_CBasePlayer_DropIdlePlayer;
+typedef IHookChainRegistryClassImpl<void, CBasePlayer> CReGameHookRegistry_CBasePlayer_DropIdlePlayer;
+
 class CReGameHookchains: public IReGameHookchains {
 public:
 	// CBasePlayer virtual
@@ -650,7 +654,8 @@ public:
 	CReGameHookRegistry_IsPenetrableEntity m_IsPenetrableEntity;
 	CReGameHookRegistry_CBasePlayer_HintMessageEx m_CBasePlayer_HintMessageEx;
 	CReGameHookRegistry_CBasePlayer_UseEmpty m_CBasePlayer_UseEmpty;
-
+	CReGameHookRegistry_CBasePlayer_DropIdlePlayer m_CBasePlayer_DropIdlePlayer;
+	
 public:
 	virtual IReGameHookRegistry_CBasePlayer_Spawn *CBasePlayer_Spawn();
 	virtual IReGameHookRegistry_CBasePlayer_Precache *CBasePlayer_Precache();
@@ -758,6 +763,7 @@ public:
 	virtual IReGameHookRegistry_IsPenetrableEntity *IsPenetrableEntity();
 	virtual IReGameHookRegistry_CBasePlayer_HintMessageEx *CBasePlayer_HintMessageEx();
 	virtual IReGameHookRegistry_CBasePlayer_UseEmpty *CBasePlayer_UseEmpty();
+	virtual IReGameHookRegistry_CBasePlayer_DropIdlePlayer *CBasePlayer_DropIdlePlayer();
 };
 
 extern CReGameHookchains g_ReGameHookchains;

--- a/regamedll/dlls/player.cpp
+++ b/regamedll/dlls/player.cpp
@@ -4262,11 +4262,9 @@ void EXT_FUNC CBasePlayer::__API_HOOK(PreThink)()
 		//check if this player has been inactive for 2 rounds straight
 		if (flLastMove > CSGameRules()->m_fMaxIdlePeriod)
 		{
-			if (!IsBot() && autokick.value)
-			{
-				DropIdlePlayer();
-			}
-		}
+			DropIdlePlayer();
+		}	
+
 #ifdef REGAMEDLL_ADD
 		if (afk_bomb_drop_time.value > 0.0 && IsBombGuy())
 		{
@@ -9815,21 +9813,24 @@ LINK_HOOK_CLASS_VOID_CHAIN2(CBasePlayer, DropIdlePlayer)
 
 void EXT_FUNC CBasePlayer::__API_HOOK(DropIdlePlayer)()
 {
-	edict_t *pEntity = edict();
-
-	// Log the kick
-	UTIL_LogPrintf("\"%s<%i><%s><%s>\" triggered \"Game_idle_kick\" (auto)\n", STRING(pev->netname), GETPLAYERUSERID(pEntity), GETPLAYERAUTHID(pEntity), GetTeam(m_iTeam));
-	UTIL_ClientPrintAll(HUD_PRINTCONSOLE, "#Game_idle_kick", STRING(pev->netname));
-
-#ifdef REGAMEDLL_FIXES
-	int iUserID = GETPLAYERUSERID(pEntity);
-	if (iUserID != -1)
+	if (!IsBot() && autokick.value)
 	{
-		SERVER_COMMAND(UTIL_VarArgs("kick #%d \"Player idle\"\n", iUserID));
-	}
-#else
-	SERVER_COMMAND(UTIL_VarArgs("kick \"%s\"\n", STRING(pev->netname)));
-#endif // #ifdef REGAMEDLL_FIXES
+		edict_t *pEntity = edict();
 
-	m_fLastMovement = gpGlobals->time;	
+		// Log the kick
+		UTIL_LogPrintf("\"%s<%i><%s><%s>\" triggered \"Game_idle_kick\" (auto)\n", STRING(pev->netname), GETPLAYERUSERID(pEntity), GETPLAYERAUTHID(pEntity), GetTeam(m_iTeam));
+		UTIL_ClientPrintAll(HUD_PRINTCONSOLE, "#Game_idle_kick", STRING(pev->netname));
+
+	#ifdef REGAMEDLL_FIXES
+		int iUserID = GETPLAYERUSERID(pEntity);
+		if (iUserID != -1)
+		{
+			SERVER_COMMAND(UTIL_VarArgs("kick #%d \"Player idle\"\n", iUserID));
+		}
+	#else
+		SERVER_COMMAND(UTIL_VarArgs("kick \"%s\"\n", STRING(pev->netname)));
+	#endif // #ifdef REGAMEDLL_FIXES
+
+		m_fLastMovement = gpGlobals->time;
+	}	
 }

--- a/regamedll/dlls/player.cpp
+++ b/regamedll/dlls/player.cpp
@@ -4264,21 +4264,7 @@ void EXT_FUNC CBasePlayer::__API_HOOK(PreThink)()
 		{
 			if (!IsBot() && autokick.value)
 			{
-				// Log the kick
-				UTIL_LogPrintf("\"%s<%i><%s><%s>\" triggered \"Game_idle_kick\" (auto)\n", STRING(pev->netname), GETPLAYERUSERID(edict()), GETPLAYERAUTHID(edict()), GetTeam(m_iTeam));
-				UTIL_ClientPrintAll(HUD_PRINTCONSOLE, "#Game_idle_kick", STRING(pev->netname));
-
-#ifdef REGAMEDLL_FIXES
-				int iUserID = GETPLAYERUSERID(edict());
-				if (iUserID != -1)
-				{
-					SERVER_COMMAND(UTIL_VarArgs("kick #%d \"Player idle\"\n", iUserID));
-				}
-#else
-				SERVER_COMMAND(UTIL_VarArgs("kick \"%s\"\n", STRING(pev->netname)));
-#endif // #ifdef REGAMEDLL_FIXES
-
-				m_fLastMovement = gpGlobals->time;
+				DropIdlePlayer();
 			}
 		}
 #ifdef REGAMEDLL_ADD
@@ -9823,4 +9809,27 @@ void CBasePlayer::__API_HOOK(RemoveSpawnProtection)()
 	}
 
 	CSPlayer()->m_flSpawnProtectionEndTime = 0.0f;
+}
+
+LINK_HOOK_CLASS_VOID_CHAIN2(CBasePlayer, DropIdlePlayer)
+
+void EXT_FUNC CBasePlayer::__API_HOOK(DropIdlePlayer)()
+{
+	edict_t *pEntity = edict();
+
+	// Log the kick
+	UTIL_LogPrintf("\"%s<%i><%s><%s>\" triggered \"Game_idle_kick\" (auto)\n", STRING(pev->netname), GETPLAYERUSERID(pEntity), GETPLAYERAUTHID(pEntity), GetTeam(m_iTeam));
+	UTIL_ClientPrintAll(HUD_PRINTCONSOLE, "#Game_idle_kick", STRING(pev->netname));
+
+#ifdef REGAMEDLL_FIXES
+	int iUserID = GETPLAYERUSERID(pEntity);
+	if (iUserID != -1)
+	{
+		SERVER_COMMAND(UTIL_VarArgs("kick #%d \"Player idle\"\n", iUserID));
+	}
+#else
+	SERVER_COMMAND(UTIL_VarArgs("kick \"%s\"\n", STRING(pev->netname)));
+#endif // #ifdef REGAMEDLL_FIXES
+
+	m_fLastMovement = gpGlobals->time;	
 }

--- a/regamedll/dlls/player.h
+++ b/regamedll/dlls/player.h
@@ -425,6 +425,7 @@ public:
 	void RemoveSpawnProtection_OrigFunc();
 	bool HintMessageEx_OrigFunc(const char *pMessage, float duration = 6.0f, bool bDisplayIfPlayerDead = false, bool bOverride = false);
 	void UseEmpty_OrigFunc();
+	void DropIdlePlayer_OrigFunc();
 
 	CCSPlayer *CSPlayer() const;
 #endif // REGAMEDLL_API
@@ -621,6 +622,7 @@ public:
 	void SetSpawnProtection(float flProtectionTime);
 	void RemoveSpawnProtection();
 	void UseEmpty();
+	void DropIdlePlayer();
 
 	// templates
 	template<typename T = CBasePlayerItem, typename Functor>

--- a/regamedll/public/regamedll/regamedll_api.h
+++ b/regamedll/public/regamedll/regamedll_api.h
@@ -444,6 +444,10 @@ typedef IHookChainRegistryClass<bool, class CBasePlayer, const char *, float, bo
 typedef IHookChainClass<void, class CBasePlayer> IReGameHook_CBasePlayer_UseEmpty;
 typedef IHookChainRegistryClass<void, class CBasePlayer> IReGameHookRegistry_CBasePlayer_UseEmpty;
 
+// CBasePlayer::DropIdlePlayer hook
+typedef IHookChainClass<void, CBasePlayer> IReGameHook_CBasePlayer_DropIdlePlayer;
+typedef IHookChainRegistryClass<void, CBasePlayer> IReGameHookRegistry_CBasePlayer_DropIdlePlayer;
+
 class IReGameHookchains {
 public:
 	virtual ~IReGameHookchains() {}
@@ -554,6 +558,7 @@ public:
 	virtual IReGameHookRegistry_IsPenetrableEntity *IsPenetrableEntity() = 0;
 	virtual IReGameHookRegistry_CBasePlayer_HintMessageEx *CBasePlayer_HintMessageEx() = 0;
 	virtual IReGameHookRegistry_CBasePlayer_UseEmpty *CBasePlayer_UseEmpty() = 0;
+	virtual IReGameHookRegistry_CBasePlayer_DropIdlePlayer *CBasePlayer_DropIdlePlayer() = 0;
 };
 
 struct ReGameFuncs_t {


### PR DESCRIPTION
It will expand the capabilities of the standard afk checker to the needs of the user, without need to block standard functionality of ReGameDLL.