### PR TITLE
Ignore spawns count

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Archive's bin directory contains 2 subdirectories, 'bugfixed' and 'pure'
 | mp_radio_maxinround                | 60      | -   | -            | Maximum Radio messages count for player per round.<br/>`0` disable radio messages |
 | mp_buy_anywhere                    | 0       | 0   | 3            | When set, players can buy anywhere, not only in buyzones.<br/> `0` disabled.<br/>`1` both teams <br/>`2` only Terrorists team <br/>`3` only CT team |
 | mp_weapons_allow_map_placed        | 1       | 0   | 1            | When set, map weapons (located on the floor by map) will be shown.<br/> `0` hide all map weapons.<br/>`1` enabled<br/>`NOTE`: Effect will work after round restart. |
-| mp_ignore_spawnpoints              | 0       | 0   | 1            | Allow join team even if there are not enough spawn points (for use BadSpawnPreventer/Fail Spawn Protector) |
+| mp_ignore_spawnpoints              | 0       | 0   | 1            | Allow join team even if there are not enough spawn points (for use with Resemiclip or BadSpawnPreventer/Fail Spawn Protector) |
 </details>
 
 ## How to install zBot for CS 1.6?

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Archive's bin directory contains 2 subdirectories, 'bugfixed' and 'pure'
 | mp_radio_maxinround                | 60      | -   | -            | Maximum Radio messages count for player per round.<br/>`0` disable radio messages |
 | mp_buy_anywhere                    | 0       | 0   | 3            | When set, players can buy anywhere, not only in buyzones.<br/> `0` disabled.<br/>`1` both teams <br/>`2` only Terrorists team <br/>`3` only CT team |
 | mp_weapons_allow_map_placed        | 1       | 0   | 1            | When set, map weapons (located on the floor by map) will be shown.<br/> `0` hide all map weapons.<br/>`1` enabled<br/>`NOTE`: Effect will work after round restart. |
+| mp_ignore_spawnpoints              | 0       | 0   | 1            | Allow join team even if there are not enough spawn points (for use BadSpawnPreventer/Fail Spawn Protector) |
 </details>
 
 ## How to install zBot for CS 1.6?

--- a/dist/game.cfg
+++ b/dist/game.cfg
@@ -344,3 +344,11 @@ mp_unduck_method 0
 //
 // Default value: "1"
 mp_weapons_allow_map_placed 1
+
+// Allow join team even if there are not enough spawn points
+//     (for use Semiclip/BadSpawnPreventer/Fail Spawn Protector/etc)
+// Need set mp_kill_filled_spawn to 0
+// 0 - Disabled
+// 1 - Enabled
+// Default value: "0"
+mp_ignore_spawnpoints 0

--- a/regamedll/dlls/game.cpp
+++ b/regamedll/dlls/game.cpp
@@ -141,6 +141,8 @@ cvar_t ff_damage_reduction_other        = { "ff_damage_reduction_other",        
 cvar_t radio_timeout           = { "mp_radio_timeout", "1.5", FCVAR_SERVER, 1.5f, nullptr };
 cvar_t radio_maxinround        = { "mp_radio_maxinround", "60", FCVAR_SERVER, 60.0f, nullptr };
 
+cvar_t ignore_spawnpoints = { "mp_ignore_spawnpoints", "0", 0, 0.0f, nullptr };
+
 void GameDLL_Version_f()
 {
 	if (Q_stricmp(CMD_ARGV(1), "version") != 0)
@@ -352,6 +354,8 @@ void EXT_FUNC GameDLLInit()
 
 	CVAR_REGISTER(&radio_timeout);
 	CVAR_REGISTER(&radio_maxinround);
+
+	CVAR_REGISTER(&ignore_spawnpoints);
 
 	// print version
 	CONSOLE_ECHO("ReGameDLL version: " APP_VERSION "\n");

--- a/regamedll/dlls/game.h
+++ b/regamedll/dlls/game.h
@@ -171,6 +171,7 @@ extern cvar_t ff_damage_reduction_grenade_self;
 extern cvar_t ff_damage_reduction_other;
 extern cvar_t radio_timeout;
 extern cvar_t radio_maxinround;
+extern cvar_t ignore_spawnpoints;
 
 #endif
 

--- a/regamedll/dlls/multiplay_gamerules.cpp
+++ b/regamedll/dlls/multiplay_gamerules.cpp
@@ -2981,6 +2981,17 @@ void CHalfLifeMultiplay::CheckLevelInitialized()
 		while ((pEnt = UTIL_FindEntityByClassname(pEnt, "info_player_start")))
 			m_iSpawnPointCount_CT++;
 
+
+#ifdef REGAMEDLL_FIXES
+		if (ignore_spawnpoints.value == 1.0f)
+		{
+			if (m_iSpawnPointCount_Terrorist > 0 && m_iSpawnPointCount_Terrorist < 20)
+				m_iSpawnPointCount_Terrorist = 20;
+			if (m_iSpawnPointCount_CT > 0 && m_iSpawnPointCount_CT < 20)
+				m_iSpawnPointCount_CT = 20;
+		}
+#endif
+
 		m_bLevelInitialized = true;
 	}
 }
@@ -4932,7 +4943,7 @@ TeamName CHalfLifeMultiplay::SelectDefaultTeam()
 		// Teams and scores are equal, pick a random team
 		team = (RANDOM_LONG(0, 1) == 0) ? CT : TERRORIST;
 	}
-
+	
 	if (TeamFull(team))
 	{
 		// Pick the opposite team


### PR DESCRIPTION
Ignore the number of spawn points.
It requires mp_kill_filled_spawn 0, and it is recommended to use with resemiclip.