### PR TITLE
Player reset zoom & speed.

### DIFF
--- a/regamedll/dlls/func_tank.cpp
+++ b/regamedll/dlls/func_tank.cpp
@@ -245,7 +245,11 @@ BOOL CFuncTank::StartControl(CBasePlayer *pController)
 #endif
 
 #ifdef REGAMEDLL_FIXES
-		m_pController->m_iFOV = DEFAULT_FOV;
+		// if (m_pController->m_iFOV != DEFAULT_FOV)
+		{
+			m_pController->pev->fov = m_pController->m_iFOV = m_pController->m_iLastZoom = DEFAULT_FOV;
+			m_pController->m_bResumeZoom = false;
+		}
 #endif
 	}
 

--- a/regamedll/dlls/player.cpp
+++ b/regamedll/dlls/player.cpp
@@ -1611,6 +1611,8 @@ void CBasePlayer::RemoveAllItems(BOOL removeSuit)
 
 	m_bHasNightVision = false;
 	SendItemStatus();
+
+	ResetMaxSpeed();
 #endif
 
 	// send Selected Weapon Message to our client

--- a/regamedll/dlls/player.cpp
+++ b/regamedll/dlls/player.cpp
@@ -6679,6 +6679,17 @@ BOOL EXT_FUNC CBasePlayer::__API_HOOK(RemovePlayerItem)(CBasePlayerItem *pItem)
 	if (m_pActiveItem == pItem)
 	{
 		ResetAutoaim();
+
+#ifdef REGAMEDLL_FIXES
+		// if (m_iFOV != DEFAULT_FOV)
+		{
+			pev->fov = m_iFOV = m_iLastZoom = DEFAULT_FOV;
+			m_bResumeZoom = false;
+
+			ResetMaxSpeed();
+		}
+#endif
+
 		pItem->pev->nextthink = 0;
 
 		pItem->SetThink(nullptr);

--- a/regamedll/dlls/player.cpp
+++ b/regamedll/dlls/player.cpp
@@ -1596,6 +1596,14 @@ void CBasePlayer::RemoveAllItems(BOOL removeSuit)
 	pev->viewmodel = 0;
 	pev->weaponmodel = 0;
 
+#ifdef REGAMEDLL_FIXES
+	// if (m_iFOV != DEFAULT_FOV)
+	{
+		pev->fov = m_iFOV = m_iLastZoom = DEFAULT_FOV;
+		m_bResumeZoom = false;
+	}
+#endif
+
 	if (removeSuit)
 		pev->weapons = 0;
 	else


### PR DESCRIPTION
You have only one AWP weapon (without knife) If you drop a weapon with zoom, then the player does not reset speed and zoom.