### PR TITLE
Update CBuyZone::BuyTouch

### DIFF
--- a/regamedll/dlls/triggers.cpp
+++ b/regamedll/dlls/triggers.cpp
@@ -1819,6 +1819,16 @@ void CBuyZone::BuyTouch(CBaseEntity *pOther)
 			return;
 #endif
 
+#ifdef REGAMEDLL_ADD
+		if (buy_anywhere.value == 1
+			|| (buy_anywhere.value == 2 && pPlayer->m_iTeam == TERRORIST)
+			|| (buy_anywhere.value == 3 && pPlayer->m_iTeam == CT)
+			)
+		{
+			return;
+		}
+#endif
+
 		pPlayer->m_signals.Signal(SIGNAL_BUY);
 	}
 }


### PR DESCRIPTION
Closes #574 
Fixes buy icon disappear if player sends fullupdate while standing inside buyzone when mp_buy_anywhere is 1 or matches team
Video: https://www.youtube.com/watch?v=8jAt7rjmlsc