### PR TITLE
Fixed memory leak with hintmessage.

### DIFF
--- a/regamedll/dlls/hintmessage.cpp
+++ b/regamedll/dlls/hintmessage.cpp
@@ -15,10 +15,7 @@ CHintMessage::CHintMessage(const char *hintString, bool isHint, CUtlVector<const
 
 CHintMessage::~CHintMessage()
 {
-	for (int i = 0; i < m_args.Count(); i++)
-		delete[] m_args[i];
-
-	m_args.RemoveAll();
+	m_args.PurgeAndDeleteArrays();
 }
 
 void CHintMessage::Send(CBaseEntity *client)
@@ -29,14 +26,7 @@ void CHintMessage::Send(CBaseEntity *client)
 void CHintMessageQueue::Reset()
 {
 	m_tmMessageEnd = 0;
-#ifdef REGAMEDLL_FIXES
 	m_messages.PurgeAndDeleteElements();
-#else
-	for (int i = 0; i < m_messages.Count(); i++)
-		delete m_messages[i];
-
-	m_messages.RemoveAll();
-#endif
 }
 
 void CHintMessageQueue::Update(CBaseEntity *client)

--- a/regamedll/dlls/hintmessage.cpp
+++ b/regamedll/dlls/hintmessage.cpp
@@ -29,11 +29,14 @@ void CHintMessage::Send(CBaseEntity *client)
 void CHintMessageQueue::Reset()
 {
 	m_tmMessageEnd = 0;
-
+#ifdef REGAMEDLL_FIXES
+	m_messages.PurgeAndDeleteElements();
+#else
 	for (int i = 0; i < m_messages.Count(); i++)
 		delete m_messages[i];
 
 	m_messages.RemoveAll();
+#endif
 }
 
 void CHintMessageQueue::Update(CBaseEntity *client)

--- a/regamedll/dlls/player.cpp
+++ b/regamedll/dlls/player.cpp
@@ -99,6 +99,7 @@ void CBasePlayer::OnDestroy()
 		delete[] m_rebuyString;
 		m_rebuyString = nullptr;
 	}
+	m_hintMessageQueue.Reset();
 }
 #endif
 

--- a/regamedll/public/utlvector.h
+++ b/regamedll/public/utlvector.h
@@ -121,6 +121,7 @@ public:
 
 	// Purges the list and calls delete on each element in it.
 	void PurgeAndDeleteElements();
+	void PurgeAndDeleteArrays();
 
 	// Set the size by which it grows when it needs to allocate more memory.
 	void SetGrowSize(int size);
@@ -543,6 +544,15 @@ inline void CUtlVector<T>::PurgeAndDeleteElements()
 {
 	for (int i = 0; i < m_Size; i++)
 		delete Element(i);
+
+	Purge();
+}
+
+template <class T>
+inline void CUtlVector<T>::PurgeAndDeleteArrays()
+{
+	for (int i = 0; i < m_Size; i++)
+		delete[] Element(i);
 
 	Purge();
 }


### PR DESCRIPTION
Discovered when running under AddressSanitizer.

```
Direct leak of 94992 byte(s) in 271 object(s) allocated from:
    #0 0xf79e74bb in __interceptor_malloc (/usr/lib/gcc/i686-linux-gnu/10/libasan.so+0xac4bb)
    #1 0xeca1553b in CUtlMemory<CHintMessage*, int>::Grow(int) /home/j4/github/ReGameDLL_CS/regamedll/public/utlmemory.h:294
    #2 0xeca1553b in CUtlVector<CHintMessage*>::GrowVector(int) /home/j4/github/ReGameDLL_CS/regamedll/public/utlvector.h:260
    #3 0xeca1553b in CUtlVector<CHintMessage*>::InsertBefore(int, CHintMessage* const&) /home/j4/github/ReGameDLL_CS/regamedll/public/utlvector.h:364
    #4 0xeca1553b in CUtlVector<CHintMessage*>::AddToTail(CHintMessage* const&) /home/j4/github/ReGameDLL_CS/regamedll/public/utlvector.h:349
    #5 0xeca1553b in CHintMessageQueue::AddMessage(char const*, float, bool, CUtlVector<char const*>*) /home/j4/github/ReGameDLL_CS/regamedll/dlls/hintmessage.cpp:53

```