### PR TITLE
Fix compatibility whit rg_hint_message

### DIFF
--- a/regamedll/dlls/hintmessage.cpp
+++ b/regamedll/dlls/hintmessage.cpp
@@ -2,7 +2,7 @@
 
 CHintMessage::CHintMessage(const char *hintString, bool isHint, CUtlVector<const char *> *args, float duration)
 {
-	m_hintString = hintString;
+	m_hintString = CloneString(hintString);
 	m_duration = duration;
 	m_isHint = isHint;
 
@@ -16,11 +16,17 @@ CHintMessage::CHintMessage(const char *hintString, bool isHint, CUtlVector<const
 CHintMessage::~CHintMessage()
 {
 	m_args.PurgeAndDeleteArrays();
+
+	if (m_hintString)
+	{
+		delete[] m_hintString;
+		m_hintString = NULL;
+	}
 }
 
 void CHintMessage::Send(CBaseEntity *client)
 {
-	UTIL_ShowMessageArgs(m_hintString.c_str(), client, &m_args, m_isHint);
+	UTIL_ShowMessageArgs(m_hintString, client, &m_args, m_isHint);
 }
 
 void CHintMessageQueue::Reset()

--- a/regamedll/dlls/hintmessage.cpp
+++ b/regamedll/dlls/hintmessage.cpp
@@ -20,7 +20,7 @@ CHintMessage::~CHintMessage()
 
 void CHintMessage::Send(CBaseEntity *client)
 {
-	UTIL_ShowMessageArgs(m_hintString, client, &m_args, m_isHint);
+	UTIL_ShowMessageArgs(m_hintString.c_str(), client, &m_args, m_isHint);
 }
 
 void CHintMessageQueue::Reset()

--- a/regamedll/dlls/hintmessage.h
+++ b/regamedll/dlls/hintmessage.h
@@ -65,7 +65,7 @@ public:
 	void Send(CBaseEntity *client);
 
 private:
-	std::string m_hintString;
+	char *m_hintString;
 	bool m_isHint;
 	CUtlVector<char *> m_args;
 	float m_duration;

--- a/regamedll/dlls/hintmessage.h
+++ b/regamedll/dlls/hintmessage.h
@@ -65,7 +65,7 @@ public:
 	void Send(CBaseEntity *client);
 
 private:
-	const char *m_hintString;
+	std::string m_hintString;
 	bool m_isHint;
 	CUtlVector<char *> m_args;
 	float m_duration;


### PR DESCRIPTION
When using ReAPI native rg_hint_message it won't work correctly because it tries to access to a pointer which does not exists in CHintMessage::Send.