### PR TITLE
regamedll-cs.fgd

### DIFF
--- a/regamedll/extra/Toolkit/GameDefinitionFile/regamedll-cs.fgd
+++ b/regamedll/extra/Toolkit/GameDefinitionFile/regamedll-cs.fgd
@@ -2622,8 +2622,8 @@
 		1 : "Not solid" : 0
 		2 : "Reverse Dir" : 0
 		32: "Toggle" : 0
-		64: "X Axis" : 0
-		128: "Y Axis" : 0
+		64: "Z Axis" : 0
+		128: "X Axis" : 0
 		256: "Touch Activates": 0
 	]
 	_minlight(string) : "Minimum light level" : "0"

--- a/regamedll/extra/Toolkit/GameDefinitionFile/regamedll-cs.fgd
+++ b/regamedll/extra/Toolkit/GameDefinitionFile/regamedll-cs.fgd
@@ -2622,6 +2622,8 @@
 		1 : "Not solid" : 0
 		2 : "Reverse Dir" : 0
 		32: "Toggle" : 0
+		64: "X Axis" : 0
+		128: "Y Axis" : 0
 		256: "Touch Activates": 0
 	]
 	_minlight(string) : "Minimum light level" : "0"


### PR DESCRIPTION
Добавлены пропавшие spawnflags 64 и 128 у func_rot_button, которые определяют вращение по конкретной оси(стандарт Z).