### PR TITLE
Implement `CBasePlayer::Observer_FindNextPlayer()` hook

### DIFF
--- a/regamedll/dlls/API/CAPI_Impl.cpp
+++ b/regamedll/dlls/API/CAPI_Impl.cpp
@@ -87,6 +87,7 @@ GAMEHOOK_REGISTRY(CBasePlayer_RoundRespawn);
 GAMEHOOK_REGISTRY(CBasePlayer_Blind);
 
 GAMEHOOK_REGISTRY(CBasePlayer_Observer_IsValidTarget);
+GAMEHOOK_REGISTRY(CBasePlayer_Observer_FindNextPlayer);
 GAMEHOOK_REGISTRY(CBasePlayer_SetAnimation);
 GAMEHOOK_REGISTRY(CBasePlayer_GiveDefaultItems);
 GAMEHOOK_REGISTRY(CBasePlayer_GiveNamedItem);

--- a/regamedll/dlls/API/CAPI_Impl.h
+++ b/regamedll/dlls/API/CAPI_Impl.h
@@ -253,6 +253,10 @@ typedef IHookChainRegistryClassImpl<void, CBasePlayer, float, float, float, int>
 typedef IHookChainClassImpl<CBasePlayer *, CBasePlayer, int, bool> CReGameHook_CBasePlayer_Observer_IsValidTarget;
 typedef IHookChainRegistryClassImpl<CBasePlayer *, CBasePlayer, int, bool> CReGameHookRegistry_CBasePlayer_Observer_IsValidTarget;
 
+// CBasePlayer::Observer_FindNextPlayer hook
+typedef IHookChainClassImpl<void, CBasePlayer, bool, const char *> CReGameHook_CBasePlayer_Observer_FindNextPlayer;
+typedef IHookChainRegistryClassImpl<void, CBasePlayer, bool, const char *> CReGameHookRegistry_CBasePlayer_Observer_FindNextPlayer;
+
 // CBasePlayer::SetAnimation hook
 typedef IHookChainClassImpl<void, CBasePlayer, PLAYER_ANIM> CReGameHook_CBasePlayer_SetAnimation;
 typedef IHookChainRegistryClassImpl<void, CBasePlayer, PLAYER_ANIM> CReGameHookRegistry_CBasePlayer_SetAnimation;
@@ -660,6 +664,7 @@ public:
 	CReGameHookRegistry_CBasePlayer_Blind m_CBasePlayer_Blind;
 
 	CReGameHookRegistry_CBasePlayer_Observer_IsValidTarget m_CBasePlayer_Observer_IsValidTarget;
+	CReGameHookRegistry_CBasePlayer_Observer_FindNextPlayer m_CBasePlayer_Observer_FindNextPlayer;
 	CReGameHookRegistry_CBasePlayer_SetAnimation m_CBasePlayer_SetAnimation;
 	CReGameHookRegistry_CBasePlayer_GiveDefaultItems m_CBasePlayer_GiveDefaultItems;
 	CReGameHookRegistry_CBasePlayer_GiveNamedItem m_CBasePlayer_GiveNamedItem;
@@ -788,6 +793,7 @@ public:
 	virtual IReGameHookRegistry_CBasePlayer_Blind *CBasePlayer_Blind();
 
 	virtual IReGameHookRegistry_CBasePlayer_Observer_IsValidTarget *CBasePlayer_Observer_IsValidTarget();
+	virtual IReGameHookRegistry_CBasePlayer_Observer_FindNextPlayer *CBasePlayer_Observer_FindNextPlayer();
 	virtual IReGameHookRegistry_CBasePlayer_SetAnimation *CBasePlayer_SetAnimation();
 	virtual IReGameHookRegistry_CBasePlayer_GiveDefaultItems *CBasePlayer_GiveDefaultItems();
 	virtual IReGameHookRegistry_CBasePlayer_GiveNamedItem *CBasePlayer_GiveNamedItem();

--- a/regamedll/dlls/observer.cpp
+++ b/regamedll/dlls/observer.cpp
@@ -137,8 +137,10 @@ void UpdateClientEffects(CBasePlayer *pObserver, int oldMode)
 	}
 }
 
+LINK_HOOK_CLASS_VOID_CHAIN(CBasePlayer, Observer_FindNextPlayer, (bool bReverse, const char *name), bReverse, name)
+
 // Find the next client in the game for this player to spectate
-void CBasePlayer::Observer_FindNextPlayer(bool bReverse, const char *name)
+void CBasePlayer::__API_HOOK(Observer_FindNextPlayer)(bool bReverse, const char *name)
 {
 	int iStart;
 	int iCurrent;

--- a/regamedll/dlls/player.h
+++ b/regamedll/dlls/player.h
@@ -414,6 +414,7 @@ public:
 	void RoundRespawn_OrigFunc();
 	void Blind_OrigFunc(float flUntilTime, float flHoldTime, float flFadeTime, int iAlpha);
 	EXT_FUNC CBasePlayer *Observer_IsValidTarget_OrigFunc(int iPlayerIndex, bool bSameTeam);
+	EXT_FUNC void Observer_FindNextPlayer_OrigFunc(bool bReverse, const char* name = nullptr);
 	void Radio_OrigFunc(const char *msg_id, const char *msg_verbose = nullptr, short pitch = 100, bool showIcon = true);
 	void AddAccount_OrigFunc(int amount, RewardType type = RT_NONE, bool bTrackChange = true);
 	void Disappear_OrigFunc();
@@ -452,7 +453,7 @@ public:
 	static CBasePlayer *Instance(int offset) { return Instance(ENT(offset)); }
 
 	void SpawnClientSideCorpse();
-	void Observer_FindNextPlayer(bool bReverse, const char *name = nullptr);
+	virtual void Observer_FindNextPlayer(bool bReverse, const char *name = nullptr);
 	CBasePlayer *Observer_IsValidTarget(int iPlayerIndex, bool bSameTeam);
 	void Disconnect();
 	void Observer_Think();

--- a/regamedll/dlls/player.h
+++ b/regamedll/dlls/player.h
@@ -453,7 +453,7 @@ public:
 	static CBasePlayer *Instance(int offset) { return Instance(ENT(offset)); }
 
 	void SpawnClientSideCorpse();
-	virtual void Observer_FindNextPlayer(bool bReverse, const char *name = nullptr);
+	void Observer_FindNextPlayer(bool bReverse, const char *name = nullptr);
 	CBasePlayer *Observer_IsValidTarget(int iPlayerIndex, bool bSameTeam);
 	void Disconnect();
 	void Observer_Think();

--- a/regamedll/public/regamedll/regamedll_api.h
+++ b/regamedll/public/regamedll/regamedll_api.h
@@ -38,7 +38,7 @@
 #include <API/CSInterfaces.h>
 
 #define REGAMEDLL_API_VERSION_MAJOR 5
-#define REGAMEDLL_API_VERSION_MINOR 22
+#define REGAMEDLL_API_VERSION_MINOR 21
 
 // CBasePlayer::Spawn hook
 typedef IHookChainClass<void, class CBasePlayer> IReGameHook_CBasePlayer_Spawn;

--- a/regamedll/public/regamedll/regamedll_api.h
+++ b/regamedll/public/regamedll/regamedll_api.h
@@ -38,7 +38,7 @@
 #include <API/CSInterfaces.h>
 
 #define REGAMEDLL_API_VERSION_MAJOR 5
-#define REGAMEDLL_API_VERSION_MINOR 21
+#define REGAMEDLL_API_VERSION_MINOR 22
 
 // CBasePlayer::Spawn hook
 typedef IHookChainClass<void, class CBasePlayer> IReGameHook_CBasePlayer_Spawn;
@@ -131,6 +131,10 @@ typedef IHookChainRegistryClass<void, class CBasePlayer, float, float, float, in
 // CBasePlayer::Observer_IsValidTarget hook
 typedef IHookChainClass<class CBasePlayer *, class CBasePlayer, int, bool> IReGameHook_CBasePlayer_Observer_IsValidTarget;
 typedef IHookChainRegistryClass<class CBasePlayer *, class CBasePlayer, int, bool> IReGameHookRegistry_CBasePlayer_Observer_IsValidTarget;
+
+// CBasePlayer::Observer_FindNextPlayer hook
+typedef IHookChainClass<void, class CBasePlayer, bool, const char *> IReGameHook_CBasePlayer_Observer_FindNextPlayer;
+typedef IHookChainRegistryClass<void, class CBasePlayer, bool, const char *> IReGameHookRegistry_CBasePlayer_Observer_FindNextPlayer;
 
 // CBasePlayer::SetAnimation hook
 typedef IHookChainClass<void, class CBasePlayer, PLAYER_ANIM> IReGameHook_CBasePlayer_SetAnimation;
@@ -541,6 +545,7 @@ public:
 	virtual IReGameHookRegistry_CBasePlayer_Blind *CBasePlayer_Blind() = 0;
 
 	virtual IReGameHookRegistry_CBasePlayer_Observer_IsValidTarget *CBasePlayer_Observer_IsValidTarget() = 0;
+	virtual IReGameHookRegistry_CBasePlayer_Observer_FindNextPlayer *CBasePlayer_Observer_FindNextPlayer() = 0;
 	virtual IReGameHookRegistry_CBasePlayer_SetAnimation *CBasePlayer_SetAnimation() = 0;
 	virtual IReGameHookRegistry_CBasePlayer_GiveDefaultItems *CBasePlayer_GiveDefaultItems() = 0;
 	virtual IReGameHookRegistry_CBasePlayer_GiveNamedItem *CBasePlayer_GiveNamedItem() = 0;


### PR DESCRIPTION
The game have a bug when you are specting in first person, quickly changing players it is possible to "bug" the game and see through walls for a fraction of a second. This hook is needed to try to fix this bug.