### PR TITLE
Grenade weaponbox ammo pickup fix

### DIFF
--- a/regamedll/dlls/weapons.cpp
+++ b/regamedll/dlls/weapons.cpp
@@ -1593,7 +1593,17 @@ int CBasePlayerWeapon::ExtractClipAmmo(CBasePlayerWeapon *pWeapon)
 		iAmmo = m_iClip;
 	}
 
-	return pWeapon->m_pPlayer->GiveAmmo(iAmmo, pszAmmo1(), iMaxAmmo1());
+	int iIdAmmo = pWeapon->m_pPlayer->GiveAmmo(iAmmo, pszAmmo1(), iMaxAmmo1());
+
+#ifdef REGAMEDLL_FIXES
+	if (iIdAmmo > 0 && IsGrenadeWeapon(m_iId))
+	{
+		// grenades have WEAPON_NOCLIP force play the "got ammo" sound.
+		EMIT_SOUND(pWeapon->m_pPlayer->edict(), CHAN_ITEM, "items/9mmclip1.wav", VOL_NORM, ATTN_NORM);
+	}
+#endif
+
+	return iIdAmmo;
 }
 
 // RetireWeapon - no more ammo for this gun, put it away.
@@ -1918,19 +1928,35 @@ void CWeaponBox::Touch(CBaseEntity *pOther)
 					int playerGrenades = pPlayer->m_rgAmmo[pGrenade->m_iPrimaryAmmoType];
 
 #ifdef REGAMEDLL_FIXES
-					auto info = GetWeaponInfo(pGrenade->m_iId);
-					if (info && playerGrenades < info->maxRounds)
-					{
-						auto pNext = m_rgpPlayerItems[i]->m_pNext;
-						if (pPlayer->AddPlayerItem(pItem))
-						{
-							pItem->AttachToPlayer(pPlayer);
-							bEmitSound = true;
-						}
+					// sorry for hardcode :(
+					const int boxAmmoSlot = 1;
 
-						// unlink this weapon from the box
-						m_rgpPlayerItems[i] = pItem = pNext;
-						continue;
+					if (playerGrenades < pGrenade->iMaxAmmo1())
+					{
+						if (m_rgAmmo[boxAmmoSlot] > 1 && playerGrenades > 0)
+						{
+							if (!FStringNull(m_rgiszAmmo[boxAmmoSlot])
+								&& pPlayer->GiveAmmo(1, STRING(m_rgiszAmmo[boxAmmoSlot]), pGrenade->iMaxAmmo1()) != -1)
+							{
+								m_rgAmmo[boxAmmoSlot]--;
+
+								EMIT_SOUND(pPlayer->edict(), CHAN_ITEM, "items/9mmclip1.wav", VOL_NORM, ATTN_NORM);
+							}
+						}
+						else
+						{
+							auto pNext = m_rgpPlayerItems[i]->m_pNext;
+
+							if (pPlayer->AddPlayerItem(pItem))
+							{
+								pItem->AttachToPlayer(pPlayer);
+								bEmitSound = true;
+							}
+
+							// unlink this weapon from the box
+							m_rgpPlayerItems[i] = pItem = pNext;
+							continue;
+						}
 					}
 #else
 


### PR DESCRIPTION
* fix bug when picking weaponbox grenades with ammo > 1
        If the player had one grenade and the weaponbox has 2 and when the player picks up one, the weaponbox disappears. 
        although it should stay with one grenade

* fix bug pickup sound (if the player has ammo > 0)


demo
https://youtu.be/k-ckR6FDJVQ