### PR TITLE
g3sg1 animation duration fix

### DIFF
--- a/regamedll/dlls/wpn_shared/wpn_g3sg1.cpp
+++ b/regamedll/dlls/wpn_shared/wpn_g3sg1.cpp
@@ -204,6 +204,12 @@ void CG3SG1::Reload()
 			m_pPlayer->m_iFOV = m_pPlayer->pev->fov = 15;
 			SecondaryAttack();
 		}
+
+#ifdef REGAMEDLL_FIXES
+		// G3SG1_RELOAD_TIME == 3.5 default model "reload" animation time 4.7 (frames 141 / fps 30)
+		m_flTimeWeaponIdle = m_flTimeWeaponIdle + 1.2f;
+#endif
+
 	}
 }
 


### PR DESCRIPTION
Changing does not touch reload time (only visual animation time changes)

ps:
G3SG1 too powerful weapon. What do you think can developers wanted to make a reload time 4.7s and not 3.5s

demo
https://youtu.be/IuOZkmebRbE
