### PR TITLE
game.cfg: set CVar `sv_alltalk` to 1 by default

### DIFF
--- a/dist/game.cfg
+++ b/dist/game.cfg
@@ -223,8 +223,8 @@ showtriggers 0
 // 4 - alive hear alive, dead hear dead and alive.
 // 5 - alive hear alive teammates, dead hear dead and alive.
 //
-// Default value: "0"
-sv_alltalk 0
+// Default value: "1"
+sv_alltalk 1
 
 // Time to remove item that have been dropped from the players. (in seconds)
 //

--- a/dist/game.cfg
+++ b/dist/game.cfg
@@ -216,7 +216,7 @@ showtriggers 0
 
 // When players can hear each other.
 // Further explanation: https://github.com/s1lentq/ReGameDLL_CS/wiki/sv_alltalk
-// 0 - dead don't hear alive
+// 0 - dead don't hear alive, alive don't hear alive enemies
 // 1 - no restrictions
 // 2 - teammates hear each other
 // 3 - same as 2, but spectators hear everybody


### PR DESCRIPTION
Why is this important?
Many users don't know about this CVar, and wonder why the players can't hear each other.
Just take a look at dev-cs or some other forums, people ask questions in revoice, VTC and gamedll threads "why the players can't hear each other?".
And a very, very small percentage of users use `sv_alltalk 0`.