### PR TITLE
`mp_free_armor` small fix

### DIFF
--- a/regamedll/dlls/player.cpp
+++ b/regamedll/dlls/player.cpp
@@ -10003,8 +10003,8 @@ void EXT_FUNC CBasePlayer::__API_HOOK(OnSpawnEquip)(bool addDefault, bool equipG
 	{
 		switch (static_cast<ArmorType>((int)free_armor.value))
 		{
-		case ARMOR_KEVLAR: GiveNamedItem("item_kevlar"); break;
-		case ARMOR_VESTHELM: GiveNamedItem("item_assaultsuit"); break;
+		case ARMOR_KEVLAR: GiveNamedItemEx("item_kevlar"); break;
+		case ARMOR_VESTHELM: GiveNamedItemEx("item_assaultsuit"); break;
 		}
 	}
 #endif


### PR DESCRIPTION
If a new round starts and a player previously had full armor points, both `item_kevlar` and `item_assaultsuit` would stay on the ground as `DispatchTouch()` doesn't give them the armor.

`GiveNamedItemEx()` is made for this.