### PR TITLE
New CVar: `mp_team_flash`

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ This means that plugins that do binary code analysis (Orpheu for example) probab
 | mp_give_player_c4                  | 1       | 0   | 1            | Whether this map should spawn a C4 bomb for a player or not.<br/> `0` disabled<br/>`1` enabled |
 | mp_weapons_allow_map_placed        | 1       | 0   | 1            | When set, map weapons (located on the floor by map) will be shown.<br/> `0` hide all map weapons.<br/>`1` enabled<br/>`NOTE`: Effect will work after round restart. |
 | mp_free_armor                      | 0       | 0   | 2            | Give free armor on player spawn.<br/>`0` disabled <br/>`1` Give Kevlar <br/>`2` Give Kevlar + Helmet |
-| mp_team_flash                      | 1       | -1  | 1            | Flashbang affects teammates.<br/>`-1` Don't affect teammates neither flash owner <br/>`0` Don't affect teammates <br/>`1` Affects teammates |
+| mp_team_flash                      | 1       | -1  | 1            | Sets the behaviour for Flashbangs on teammates.<br/>`-1` Don't affect teammates neither flash owner <br/>`0` Don't affect teammates <br/>`1` Affects teammates |
 | mp_fadetoblack                     | 0       | 0   | 2            | Observer's screen will fade to black on kill event or permanent.<br/> `0` No fade.<br/>`1` Fade to black and won't be able to watch anybody.<br/>`2` fade to black only on kill moment. |
 | mp_falldamage                      | 1       | 0   | 1            | Damage from falling.<br/>`0` disabled <br/>`1` enabled |
 | sv_allchat                         | 1       | 0   | 1            | Players can receive all other players text chat, team restrictions apply<br/>`0` disabled <br/>`1` enabled |

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ This means that plugins that do binary code analysis (Orpheu for example) probab
 | mp_give_player_c4                  | 1       | 0   | 1            | Whether this map should spawn a C4 bomb for a player or not.<br/> `0` disabled<br/>`1` enabled |
 | mp_weapons_allow_map_placed        | 1       | 0   | 1            | When set, map weapons (located on the floor by map) will be shown.<br/> `0` hide all map weapons.<br/>`1` enabled<br/>`NOTE`: Effect will work after round restart. |
 | mp_free_armor                      | 0       | 0   | 2            | Give free armor on player spawn.<br/>`0` disabled <br/>`1` Give Kevlar <br/>`2` Give Kevlar + Helmet |
+| mp_team_flash                      | 1       | -1  | 1            | Flashbang affects teammates.<br/>`-1` Don't affect teammates neither flash owner <br/>`0` Don't affect teammates <br/>`1` Affects teammates |
 | mp_fadetoblack                     | 0       | 0   | 2            | Observer's screen will fade to black on kill event or permanent.<br/> `0` No fade.<br/>`1` Fade to black and won't be able to watch anybody.<br/>`2` fade to black only on kill moment. |
 | mp_falldamage                      | 1       | 0   | 1            | Damage from falling.<br/>`0` disabled <br/>`1` enabled |
 | sv_allchat                         | 1       | 0   | 1            | Players can receive all other players text chat, team restrictions apply<br/>`0` disabled <br/>`1` enabled |

--- a/dist/game.cfg
+++ b/dist/game.cfg
@@ -456,7 +456,7 @@ mp_ct_default_weapons_secondary "usp"
 // Default value: "0"
 mp_free_armor 0
 
-// Flashbang affects teammates
+// Sets the behaviour for Flashbangs on teammates.
 // -1 - Don't affect teammates neither flash owner
 // 0  - Don't affect teammates
 // 1  - Affects teammates (default behaviour)

--- a/dist/game.cfg
+++ b/dist/game.cfg
@@ -456,6 +456,14 @@ mp_ct_default_weapons_secondary "usp"
 // Default value: "0"
 mp_free_armor 0
 
+// Flashbang affects teammates
+// -1 - Don't affect teammates neither flash owner
+// 0  - Don't affect teammates
+// 1  - Affects teammates (default behaviour)
+//
+// Default value: "1"
+mp_team_flash 1
+
 // Players can receive all other players text chat, team restrictions apply.
 // 0 - disabled (default behaviour)
 // 1 - enabled

--- a/regamedll/dlls/combat.cpp
+++ b/regamedll/dlls/combat.cpp
@@ -87,6 +87,19 @@ void RadiusFlash(Vector vecSrc, entvars_t *pevInflictor, entvars_t *pevAttacker,
 
 		if (tr2.flFraction >= 1.0)
 		{
+#ifdef REGAMEDLL_ADD
+			switch ((int)teamflash.value)
+			{
+			case 0:
+				if (pPlayer->pev != pevAttacker && g_pGameRules->PlayerRelationship(pPlayer, (CBaseEntity*)pevAttacker) == GR_TEAMMATE)
+					continue;
+				break;
+			case -1:
+				if (pPlayer->pev == pevAttacker || g_pGameRules->PlayerRelationship(pPlayer, (CBaseEntity*)pevAttacker) == GR_TEAMMATE)
+					continue;
+				break;
+			}		
+#endif
 			if (tr.fStartSolid)
 			{
 				tr.vecEndPos = vecSrc;

--- a/regamedll/dlls/combat.cpp
+++ b/regamedll/dlls/combat.cpp
@@ -91,11 +91,11 @@ void RadiusFlash(Vector vecSrc, entvars_t *pevInflictor, entvars_t *pevAttacker,
 			switch ((int)teamflash.value)
 			{
 			case 0:
-				if (pPlayer->pev != pevAttacker && g_pGameRules->PlayerRelationship(pPlayer, (CBaseEntity*)pevAttacker) == GR_TEAMMATE)
+				if (pPlayer->pev != pevAttacker && g_pGameRules->PlayerRelationship(pPlayer, CBaseEntity::Instance(pevAttacker)) == GR_TEAMMATE)
 					continue;
 				break;
 			case -1:
-				if (pPlayer->pev == pevAttacker || g_pGameRules->PlayerRelationship(pPlayer, (CBaseEntity*)pevAttacker) == GR_TEAMMATE)
+				if (pPlayer->pev == pevAttacker || g_pGameRules->PlayerRelationship(pPlayer, CBaseEntity::Instance(pevAttacker)) == GR_TEAMMATE)
 					continue;
 				break;
 			}		

--- a/regamedll/dlls/game.cpp
+++ b/regamedll/dlls/game.cpp
@@ -158,6 +158,7 @@ cvar_t t_give_player_knife               = { "mp_t_give_player_knife", "1", 0, 1
 cvar_t t_default_weapons_secondary       = { "mp_t_default_weapons_secondary", "glock18", 0, 0.0f, nullptr };
 cvar_t t_default_weapons_primary         = { "mp_t_default_weapons_primary", "", 0, 0.0f, nullptr };
 cvar_t free_armor                        = { "mp_free_armor", "0", 0, 0.0f, nullptr };
+cvar_t teamflash                         = { "mp_team_flash", "1", 0, 1.0f, nullptr };
 cvar_t allchat                           = { "sv_allchat", "0", 0, 0.0f, nullptr };
 cvar_t sv_autobunnyhopping               = { "sv_autobunnyhopping", "0", 0, 0.0f, nullptr };
 cvar_t sv_enablebunnyhopping             = { "sv_enablebunnyhopping", "0", 0, 0.0f, nullptr };
@@ -388,6 +389,7 @@ void EXT_FUNC GameDLLInit()
 	CVAR_REGISTER(&t_default_weapons_secondary);
 	CVAR_REGISTER(&t_default_weapons_primary);
 	CVAR_REGISTER(&free_armor);
+	CVAR_REGISTER(&teamflash);
 	CVAR_REGISTER(&allchat);
 	CVAR_REGISTER(&sv_autobunnyhopping);
 	CVAR_REGISTER(&sv_enablebunnyhopping);

--- a/regamedll/dlls/game.h
+++ b/regamedll/dlls/game.h
@@ -184,6 +184,7 @@ extern cvar_t t_give_player_knife;
 extern cvar_t t_default_weapons_secondary;
 extern cvar_t t_default_weapons_primary;
 extern cvar_t free_armor;
+extern cvar_t teamflash;
 extern cvar_t allchat;
 extern cvar_t sv_autobunnyhopping;
 extern cvar_t sv_enablebunnyhopping;


### PR DESCRIPTION
Related to https://github.com/s1lentq/ReGameDLL_CS/issues/572

Instead of a "No Team Flash" idea, this command alters the Flashbang's performance.
You can flash your teammates, flash yourself only or neither two cases.
This also affects on `mp_freeforall` as the players on your team are now enemies.