### PR TITLE
CItemAirBox: Fix flight to the moon!

### DIFF
--- a/regamedll/dlls/addons/item_airbox.cpp
+++ b/regamedll/dlls/addons/item_airbox.cpp
@@ -63,7 +63,7 @@ void CItemAirBox::Touch(CBaseEntity *pOther)
 
 		pev->nextthink = 0;
 		SetThink(nullptr);
-		pev->velocity.z = 0;
+		pev->velocity = g_vecZero;
 	}
 }
 
@@ -71,7 +71,7 @@ void CItemAirBox::Restart()
 {
 	CArmoury::Restart();
 	UTIL_SetOrigin(pev, pev->oldorigin);
-	pev->velocity.z = 0;
+	pev->velocity = g_vecZero;
 
 	if(m_flyup < 0)
 	{


### PR DESCRIPTION
#681 done: Prevent the item to fly non-stop toward the sky on the restart (new round usually), when we picked it up earlier.