### PR TITLE
Reset `m_flNextFollowTime` before trying to find next target after previous target death

### DIFF
--- a/regamedll/dlls/player.cpp
+++ b/regamedll/dlls/player.cpp
@@ -2105,9 +2105,7 @@ void EXT_FUNC CBasePlayer::__API_HOOK(Killed)(entvars_t *pevAttacker, int iGib)
 
 #ifdef REGAMEDLL_FIXES
 		if (pObserver->m_hObserverTarget == this)
-		{
 			pObserver->m_flNextFollowTime = 0.0f;
-		}
 #endif
 	}
 

--- a/regamedll/dlls/player.cpp
+++ b/regamedll/dlls/player.cpp
@@ -2102,6 +2102,13 @@ void EXT_FUNC CBasePlayer::__API_HOOK(Killed)(entvars_t *pevAttacker, int iGib)
 
 			pObserver->m_bNightVisionOn = false;
 		}
+
+#ifdef REGAMEDLL_FIXES
+		if (pObserver->m_hObserverTarget == this)
+		{
+			pObserver->m_flNextFollowTime = 0.0f;
+		}
+#endif
 	}
 
 	if (m_pTank)


### PR DESCRIPTION
related https://github.com/s1lentq/ReGameDLL_CS/pull/584