### PR TITLE
Fix: 'fast fire glitch' at AUG/SG552

### DIFF
--- a/regamedll/dlls/wpn_shared/wpn_aug.cpp
+++ b/regamedll/dlls/wpn_shared/wpn_aug.cpp
@@ -80,11 +80,25 @@ void CAUG::PrimaryAttack()
 {
 	if (!(m_pPlayer->pev->flags & FL_ONGROUND))
 	{
-		AUGFire(0.035 + (0.4 * m_flAccuracy), 0.0825, FALSE);
+		if (m_pPlayer->pev->fov == DEFAULT_FOV)
+		{
+			AUGFire(0.035 + (0.4 * m_flAccuracy), 0.0825, FALSE);
+		}
+		else
+		{
+			AUGFire(0.035 + (0.4 * m_flAccuracy), 0.135, FALSE);
+		}
 	}
 	else if (m_pPlayer->pev->velocity.Length2D() > 140)
 	{
-		AUGFire(0.035 + (0.07 * m_flAccuracy), 0.0825, FALSE);
+		if (m_pPlayer->pev->fov == DEFAULT_FOV)
+		{
+			AUGFire(0.035 + (0.07 * m_flAccuracy), 0.0825, FALSE);
+		}
+		else
+		{
+			AUGFire(0.035 + (0.07 * m_flAccuracy), 0.135, FALSE);
+		}
 	}
 	else if (m_pPlayer->pev->fov == DEFAULT_FOV)
 	{

--- a/regamedll/dlls/wpn_shared/wpn_aug.cpp
+++ b/regamedll/dlls/wpn_shared/wpn_aug.cpp
@@ -80,24 +80,28 @@ void CAUG::PrimaryAttack()
 {
 	if (!(m_pPlayer->pev->flags & FL_ONGROUND))
 	{
-		if (m_pPlayer->pev->fov == DEFAULT_FOV)
-		{
-			AUGFire(0.035 + (0.4 * m_flAccuracy), 0.0825, FALSE);
-		}
-		else
+#ifdef REGAMEDLL_FIXES
+		if (m_pPlayer->pev->fov != DEFAULT_FOV)
 		{
 			AUGFire(0.035 + (0.4 * m_flAccuracy), 0.135, FALSE);
+		}
+		else
+#endif
+		{
+			AUGFire(0.035 + (0.4 * m_flAccuracy), 0.0825, FALSE);
 		}
 	}
 	else if (m_pPlayer->pev->velocity.Length2D() > 140)
 	{
-		if (m_pPlayer->pev->fov == DEFAULT_FOV)
-		{
-			AUGFire(0.035 + (0.07 * m_flAccuracy), 0.0825, FALSE);
-		}
-		else
+#ifdef REGAMEDLL_FIXES
+		if (m_pPlayer->pev->fov != DEFAULT_FOV)
 		{
 			AUGFire(0.035 + (0.07 * m_flAccuracy), 0.135, FALSE);
+		}
+		else
+#endif
+		{
+			AUGFire(0.035 + (0.07 * m_flAccuracy), 0.0825, FALSE);
 		}
 	}
 	else if (m_pPlayer->pev->fov == DEFAULT_FOV)

--- a/regamedll/dlls/wpn_shared/wpn_aug.cpp
+++ b/regamedll/dlls/wpn_shared/wpn_aug.cpp
@@ -78,39 +78,19 @@ void CAUG::SecondaryAttack()
 
 void CAUG::PrimaryAttack()
 {
+	const float flCycleTime = (m_pPlayer->pev->fov == DEFAULT_FOV) ? 0.0825f : 0.135f;
+
 	if (!(m_pPlayer->pev->flags & FL_ONGROUND))
 	{
-#ifdef REGAMEDLL_FIXES
-		if (m_pPlayer->pev->fov != DEFAULT_FOV)
-		{
-			AUGFire(0.035 + (0.4 * m_flAccuracy), 0.135, FALSE);
-		}
-		else
-#endif
-		{
-			AUGFire(0.035 + (0.4 * m_flAccuracy), 0.0825, FALSE);
-		}
+		AUGFire(0.035 + (0.4 * m_flAccuracy), flCycleTime, FALSE);
 	}
 	else if (m_pPlayer->pev->velocity.Length2D() > 140)
 	{
-#ifdef REGAMEDLL_FIXES
-		if (m_pPlayer->pev->fov != DEFAULT_FOV)
-		{
-			AUGFire(0.035 + (0.07 * m_flAccuracy), 0.135, FALSE);
-		}
-		else
-#endif
-		{
-			AUGFire(0.035 + (0.07 * m_flAccuracy), 0.0825, FALSE);
-		}
-	}
-	else if (m_pPlayer->pev->fov == DEFAULT_FOV)
-	{
-		AUGFire(0.02 * m_flAccuracy, 0.0825, FALSE);
+		AUGFire(0.035 + (0.07 * m_flAccuracy), flCycleTime, FALSE);
 	}
 	else
 	{
-		AUGFire(0.02 * m_flAccuracy, 0.135, FALSE);
+		AUGFire(0.02 * m_flAccuracy, flCycleTime, FALSE);
 	}
 }
 

--- a/regamedll/dlls/wpn_shared/wpn_sg552.cpp
+++ b/regamedll/dlls/wpn_shared/wpn_sg552.cpp
@@ -77,39 +77,19 @@ void CSG552::SecondaryAttack()
 
 void CSG552::PrimaryAttack()
 {
+	const float flCycleTime = (m_pPlayer->pev->fov == DEFAULT_FOV) ? 0.0825f : 0.135f;
+
 	if (!(m_pPlayer->pev->flags & FL_ONGROUND))
 	{
-#ifdef REGAMEDLL_FIXES
-		if (m_pPlayer->pev->fov != DEFAULT_FOV)
-		{
-			SG552Fire(0.035 + (0.45 * m_flAccuracy), 0.135, FALSE);
-		}
-		else
-#endif
-		{
-			SG552Fire(0.035 + (0.45 * m_flAccuracy), 0.0825, FALSE);
-		}
+		SG552Fire(0.035 + (0.45 * m_flAccuracy), flCycleTime, FALSE);
 	}
 	else if (m_pPlayer->pev->velocity.Length2D() > 140)
 	{
-#ifdef REGAMEDLL_FIXES
-		if (m_pPlayer->pev->fov != DEFAULT_FOV)
-		{
-			SG552Fire(0.035 + (0.075 * m_flAccuracy), 0.135, FALSE);
-		}
-		else
-#endif
-		{
-			SG552Fire(0.035 + (0.075 * m_flAccuracy), 0.0825, FALSE);
-		}
-	}
-	else if (m_pPlayer->pev->fov == DEFAULT_FOV)
-	{
-		SG552Fire(0.02 * m_flAccuracy, 0.0825, FALSE);
+		SG552Fire(0.035 + (0.075 * m_flAccuracy), flCycleTime, FALSE);
 	}
 	else
 	{
-		SG552Fire(0.02 * m_flAccuracy, 0.135, FALSE);
+		SG552Fire(0.02 * m_flAccuracy, flCycleTime, FALSE);
 	}
 }
 

--- a/regamedll/dlls/wpn_shared/wpn_sg552.cpp
+++ b/regamedll/dlls/wpn_shared/wpn_sg552.cpp
@@ -79,11 +79,25 @@ void CSG552::PrimaryAttack()
 {
 	if (!(m_pPlayer->pev->flags & FL_ONGROUND))
 	{
-		SG552Fire(0.035 + (0.45 * m_flAccuracy), 0.0825, FALSE);
+		if (m_pPlayer->pev->fov == DEFAULT_FOV)
+		{
+			SG552Fire(0.035 + (0.45 * m_flAccuracy), 0.0825, FALSE);
+		}
+		else
+		{
+			SG552Fire(0.035 + (0.45 * m_flAccuracy), 0.135, FALSE);
+		}
 	}
 	else if (m_pPlayer->pev->velocity.Length2D() > 140)
 	{
-		SG552Fire(0.035 + (0.075 * m_flAccuracy), 0.0825, FALSE);
+		if (m_pPlayer->pev->fov == DEFAULT_FOV)
+		{
+			SG552Fire(0.035 + (0.075 * m_flAccuracy), 0.0825, FALSE);
+		}
+		else
+		{
+			SG552Fire(0.035 + (0.075 * m_flAccuracy), 0.135, FALSE);
+		}
 	}
 	else if (m_pPlayer->pev->fov == DEFAULT_FOV)
 	{

--- a/regamedll/dlls/wpn_shared/wpn_sg552.cpp
+++ b/regamedll/dlls/wpn_shared/wpn_sg552.cpp
@@ -79,24 +79,28 @@ void CSG552::PrimaryAttack()
 {
 	if (!(m_pPlayer->pev->flags & FL_ONGROUND))
 	{
-		if (m_pPlayer->pev->fov == DEFAULT_FOV)
-		{
-			SG552Fire(0.035 + (0.45 * m_flAccuracy), 0.0825, FALSE);
-		}
-		else
+#ifdef REGAMEDLL_FIXES
+		if (m_pPlayer->pev->fov != DEFAULT_FOV)
 		{
 			SG552Fire(0.035 + (0.45 * m_flAccuracy), 0.135, FALSE);
+		}
+		else
+#endif
+		{
+			SG552Fire(0.035 + (0.45 * m_flAccuracy), 0.0825, FALSE);
 		}
 	}
 	else if (m_pPlayer->pev->velocity.Length2D() > 140)
 	{
-		if (m_pPlayer->pev->fov == DEFAULT_FOV)
-		{
-			SG552Fire(0.035 + (0.075 * m_flAccuracy), 0.0825, FALSE);
-		}
-		else
+#ifdef REGAMEDLL_FIXES
+		if (m_pPlayer->pev->fov != DEFAULT_FOV)
 		{
 			SG552Fire(0.035 + (0.075 * m_flAccuracy), 0.135, FALSE);
+		}
+		else
+#endif
+		{
+			SG552Fire(0.035 + (0.075 * m_flAccuracy), 0.0825, FALSE);
 		}
 	}
 	else if (m_pPlayer->pev->fov == DEFAULT_FOV)


### PR DESCRIPTION
Bug is caused because of not checking weapon's FOV in some conditions.

close https://github.com/s1lentq/ReGameDLL_CS/issues/703

comment from @wopox1337 
> If we keep changing the shared code of weapons for the server side, at some point in time we will get more and more out of sync with the client side (prediction) and this will adversely affect the overall experience of the game for the average player.
> 
> I propose to leave this behavior "as is".

Well, if you don't want to merge it. Let be open to documentation.