### PR TITLE
New CVar: `mp_hostages_rescued_ratio`

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ This means that plugins that do binary code analysis (Orpheu for example) probab
 | sv_enablebunnyhopping              | 0       | 0   | 1            | Allow player speed to exceed maximum running speed.<br/>`0` disabled <br/>`1` enabled |
 | mp_plant_c4_anywhere               | 0       | 0   | 1            | When set, players can plant anywhere, not only in bombsites.<br/>`0` disabled <br/>`1` enabled |
 | mp_give_c4_frags                   | 3       | -   | -            | How many bonuses (frags) will get the player who defused or exploded the bomb. |
+| mp_hostages_rescued_ratio          | 1.0     | 0.0 | 1.0          | Ratio of hostages rescued to win the round. |
 </details>
 
 ## How to install zBot for CS 1.6?

--- a/dist/game.cfg
+++ b/dist/game.cfg
@@ -489,3 +489,8 @@ mp_plant_c4_anywhere 0
 //
 // Default value: "3"
 mp_give_c4_frags 3
+
+// Ratio of hostages rescued to win the round.
+//
+// Default value: "1"
+mp_hostages_rescued_ratio 1

--- a/regamedll/dlls/game.cpp
+++ b/regamedll/dlls/game.cpp
@@ -164,6 +164,8 @@ cvar_t sv_enablebunnyhopping             = { "sv_enablebunnyhopping", "0", 0, 0.
 cvar_t plant_c4_anywhere                 = { "mp_plant_c4_anywhere", "0", 0, 0.0f, nullptr };
 cvar_t give_c4_frags                     = { "mp_give_c4_frags", "3", 0, 3.0f, nullptr };
 
+cvar_t hostages_rescued_ratio = { "mp_hostages_rescued_ratio", "1.0", 0, 1.0f, nullptr };
+
 void GameDLL_Version_f()
 {
 	if (Q_stricmp(CMD_ARGV(1), "version") != 0)
@@ -405,6 +407,8 @@ void EXT_FUNC GameDLLInit()
 	CVAR_REGISTER(&sv_enablebunnyhopping);
 	CVAR_REGISTER(&plant_c4_anywhere);
 	CVAR_REGISTER(&give_c4_frags);
+
+	CVAR_REGISTER(&hostages_rescued_ratio);
 
 	// print version
 	CONSOLE_ECHO("ReGameDLL version: " APP_VERSION "\n");

--- a/regamedll/dlls/game.h
+++ b/regamedll/dlls/game.h
@@ -189,6 +189,7 @@ extern cvar_t sv_autobunnyhopping;
 extern cvar_t sv_enablebunnyhopping;
 extern cvar_t plant_c4_anywhere;
 extern cvar_t give_c4_frags;
+extern cvar_t hostages_rescued_ratio;
 
 #endif
 

--- a/regamedll/dlls/multiplay_gamerules.cpp
+++ b/regamedll/dlls/multiplay_gamerules.cpp
@@ -1486,6 +1486,12 @@ bool CHalfLifeMultiplay::HostageRescueRoundEndCheck()
 		}
 	}
 
+#ifdef REGAMEDLL_ADD
+	if (hostagesCount > 0 && m_iHostagesRescued >= (hostagesCount * hostages_rescued_ratio.value))
+	{
+		return OnRoundEnd_Intercept(WINSTATUS_CTS, ROUND_ALL_HOSTAGES_RESCUED, GetRoundRestartDelay());
+	}
+#else
 	// There are no hostages alive.. check to see if the CTs have rescued atleast 50% of them.
 	if (!bHostageAlive && hostagesCount > 0)
 	{
@@ -1494,6 +1500,7 @@ bool CHalfLifeMultiplay::HostageRescueRoundEndCheck()
 			return OnRoundEnd_Intercept(WINSTATUS_CTS, ROUND_ALL_HOSTAGES_RESCUED, GetRoundRestartDelay());
 		}
 	}
+#endif
 
 	return false;
 }

--- a/regamedll/dlls/multiplay_gamerules.cpp
+++ b/regamedll/dlls/multiplay_gamerules.cpp
@@ -1487,7 +1487,7 @@ bool CHalfLifeMultiplay::HostageRescueRoundEndCheck()
 	}
 
 #ifdef REGAMEDLL_ADD
-	if (hostagesCount > 0 && m_iHostagesRescued >= (hostagesCount * hostages_rescued_ratio.value))
+	if (hostagesCount > 0 && m_iHostagesRescued >= (hostagesCount * Q_min(hostages_rescued_ratio.value, 1.0f)))
 	{
 		return OnRoundEnd_Intercept(WINSTATUS_CTS, ROUND_ALL_HOSTAGES_RESCUED, GetRoundRestartDelay());
 	}


### PR DESCRIPTION
https://github.com/s1lentq/ReGameDLL_CS/blob/master/regamedll/dlls/multiplay_gamerules.cpp#L1471
This business logic does not work correctly because the code below does not consider by 50%.
https://github.com/s1lentq/ReGameDLL_CS/blob/master/regamedll/dlls/multiplay_gamerules.cpp#L1482

Adding cvar for ratio and and default value for compatibility.