### PR TITLE
CI: Keep the `ICC` build for releases only

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -173,6 +173,10 @@ jobs:
           fi
         shell: bash
 
+      - name: Create publish directory
+        run: |
+          mkdir -p publish/bin/linux32/cstrike/dlls
+
       - name: Build using Intel C++ Compiler 19.0 (only for release)
         if: |
           github.event_name == 'release' &&
@@ -180,10 +184,12 @@ jobs:
           startsWith(github.ref, 'refs/tags/')
         run: |
           rm -rf build-icc && CC=icc CXX=icpc cmake -B build-icc && cmake --build build-icc -j8
+          mv build-icc/regamedll/cs.so publish/bin/linux32/cstrike/dlls/cs.so
 
       - name: Build using GCC Compiler 9.3
         run: |
           rm -rf build-gcc && CC=gcc CXX=g++ cmake -B build-gcc && cmake --build build-gcc -j8
+          mv build-gcc/regamedll/cs.so publish/cs-gcc.so
 
       - name: Prepare CSSDK
         run: |
@@ -192,9 +198,6 @@ jobs:
 
       - name: Move files
         run: |
-          mkdir -p publish/bin/linux32/cstrike/dlls
-          mv build-icc/regamedll/cs.so publish/bin/linux32/cstrike/dlls/cs.so
-          mv build-gcc/regamedll/cs.so publish/cs-gcc.so
           mv regamedll/version/appversion.h publish/appversion.h
           mv dist/ publish/
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -173,7 +173,11 @@ jobs:
           fi
         shell: bash
 
-      - name: Build using Intel C++ Compiler 19.0
+      - name: Build using Intel C++ Compiler 19.0 (only for release)
+        if: |
+          github.event_name == 'release' &&
+          github.event.action == 'published' &&
+          startsWith(github.ref, 'refs/tags/')
         run: |
           rm -rf build-icc && CC=icc CXX=icpc cmake -B build-icc && cmake --build build-icc -j8
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -173,10 +173,6 @@ jobs:
           fi
         shell: bash
 
-      - name: Create publish directory
-        run: |
-          mkdir -p publish/bin/linux32/cstrike/dlls
-
       - name: Build using Intel C++ Compiler 19.0 (only for release)
         if: |
           github.event_name == 'release' &&
@@ -184,12 +180,10 @@ jobs:
           startsWith(github.ref, 'refs/tags/')
         run: |
           rm -rf build-icc && CC=icc CXX=icpc cmake -B build-icc && cmake --build build-icc -j8
-          mv build-icc/regamedll/cs.so publish/bin/linux32/cstrike/dlls/cs.so
 
       - name: Build using GCC Compiler 9.3
         run: |
           rm -rf build-gcc && CC=gcc CXX=g++ cmake -B build-gcc && cmake --build build-gcc -j8
-          mv build-gcc/regamedll/cs.so publish/cs-gcc.so
 
       - name: Prepare CSSDK
         run: |
@@ -198,6 +192,9 @@ jobs:
 
       - name: Move files
         run: |
+          mkdir -p publish/bin/linux32/cstrike/dlls
+          mv build-icc/regamedll/cs.so publish/bin/linux32/cstrike/dlls/cs.so
+          mv build-gcc/regamedll/cs.so publish/cs-gcc.so
           mv regamedll/version/appversion.h publish/appversion.h
           mv dist/ publish/
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -193,7 +193,7 @@ jobs:
       - name: Move files
         run: |
           mkdir -p publish/bin/linux32/cstrike/dlls
-          mv build-icc/regamedll/cs.so publish/bin/linux32/cstrike/dlls/cs.so
+          mv build-icc/regamedll/cs.so publish/bin/linux32/cstrike/dlls/cs.so 2>/dev/null || true
           mv build-gcc/regamedll/cs.so publish/cs-gcc.so
           mv regamedll/version/appversion.h publish/appversion.h
           mv dist/ publish/


### PR DESCRIPTION
This way it will take less time to build a project caused by Pull requests.
Building with `ICC` is left for releases only.