### PR TITLE
swapteams cmd unintended behaviour (?)

### DIFF
--- a/regamedll/dlls/game.cpp
+++ b/regamedll/dlls/game.cpp
@@ -1,5 +1,4 @@
 #include "precompiled.h"
-#include "version/appversion.h"
 
 cvar_t *g_pskill          = nullptr;
 cvar_t *g_psv_gravity     = nullptr;

--- a/regamedll/dlls/game.cpp
+++ b/regamedll/dlls/game.cpp
@@ -1,4 +1,5 @@
 #include "precompiled.h"
+#include "version/appversion.h"
 
 cvar_t *g_pskill          = nullptr;
 cvar_t *g_psv_gravity     = nullptr;
@@ -214,6 +215,7 @@ void GameDLL_SwapTeams_f()
 	{
 		CVAR_SET_FLOAT("sv_restartround", value);
 	}
+
 }
 
 #endif // REGAMEDLL_ADD

--- a/regamedll/dlls/gamerules.h
+++ b/regamedll/dlls/gamerules.h
@@ -742,6 +742,7 @@ public:
 	bool m_bLevelInitialized;
 	bool m_bRoundTerminating;
 	bool m_bCompleteReset;					// Set to TRUE to have the scores reset next time round restarts
+	bool m_bSwapped;
 	float m_flRequiredEscapeRatio;
 	int m_iNumEscapers;
 	int m_iHaveEscaped;


### PR DESCRIPTION
Currently using swapteams with any positive number will result into unintended behaviour.

Team/Player scores get resetted on sv_restartround, I added a boolean to check for that and prevent this behaviour when swapteams is used.