### PR TITLE
fix swapteams not saving player/team scores (sv_restartround logic)

### DIFF
--- a/regamedll/dlls/game.cpp
+++ b/regamedll/dlls/game.cpp
@@ -212,6 +212,7 @@ void GameDLL_SwapTeams_f()
 
 	if (value > 0.0f)
 	{
+		g_bSwappedTeams = true;
 		CVAR_SET_FLOAT("sv_restartround", value);
 	}
 }

--- a/regamedll/dlls/globals.cpp
+++ b/regamedll/dlls/globals.cpp
@@ -12,3 +12,4 @@ bool g_bIsBeta = false;
 bool g_bIsCzeroGame = false;
 bool g_bAllowedCSBot = false;
 bool g_bHostageImprov = false;
+bool g_bSwappedTeams = false;

--- a/regamedll/dlls/globals.h
+++ b/regamedll/dlls/globals.h
@@ -39,3 +39,4 @@ extern bool g_bIsBeta;
 extern bool g_bIsCzeroGame;
 extern bool g_bAllowedCSBot;
 extern bool g_bHostageImprov;
+extern bool g_bSwappedTeams;

--- a/regamedll/dlls/multiplay_gamerules.cpp
+++ b/regamedll/dlls/multiplay_gamerules.cpp
@@ -1778,8 +1778,11 @@ void EXT_FUNC CHalfLifeMultiplay::__API_HOOK(RestartRound)()
 			m_flTimeLimit = gpGlobals->time + (timelimit.value * 60);
 
 		// Reset total # of rounds played
-		m_iTotalRoundsPlayed = 0;
-		m_iMaxRounds = int(CVAR_GET_FLOAT("mp_maxrounds"));
+		if (!g_bSwappedTeams)
+		{
+			m_iTotalRoundsPlayed = 0;
+			m_iMaxRounds = int(CVAR_GET_FLOAT("mp_maxrounds"));
+		}
 
 		if (m_iMaxRounds < 0)
 		{
@@ -1796,10 +1799,13 @@ void EXT_FUNC CHalfLifeMultiplay::__API_HOOK(RestartRound)()
 		}
 
 		// Reset score info
-		m_iNumTerroristWins = 0;
-		m_iNumCTWins = 0;
-		m_iNumConsecutiveTerroristLoses = 0;
-		m_iNumConsecutiveCTLoses = 0;
+		if (!g_bSwappedTeams)
+		{
+			m_iNumTerroristWins = 0;
+			m_iNumCTWins = 0;
+			m_iNumConsecutiveTerroristLoses = 0;
+			m_iNumConsecutiveCTLoses = 0;
+		}
 
 		// Reset team scores
 		UpdateTeamScores();
@@ -1960,10 +1966,13 @@ void EXT_FUNC CHalfLifeMultiplay::__API_HOOK(RestartRound)()
 		m_iAccountTerrorist = m_iAccountCT = 0;
 
 		// We are starting fresh. So it's like no one has ever won or lost.
-		m_iNumTerroristWins = 0;
-		m_iNumCTWins = 0;
-		m_iNumConsecutiveTerroristLoses = 0;
-		m_iNumConsecutiveCTLoses = 0;
+		if (!g_bSwappedTeams)
+		{
+			m_iNumTerroristWins = 0;
+			m_iNumCTWins = 0;
+			m_iNumConsecutiveTerroristLoses = 0;
+			m_iNumConsecutiveCTLoses = 0;
+		}
 		m_iLoserBonus = m_rgRewardAccountRules[RR_LOSER_BONUS_DEFAULT];
 	}
 
@@ -2077,6 +2086,7 @@ void EXT_FUNC CHalfLifeMultiplay::__API_HOOK(RestartRound)()
 	m_bTargetBombed = m_bBombDefused = false;
 	m_bLevelInitialized = false;
 	m_bCompleteReset = false;
+	g_bSwappedTeams = false;
 
 #ifdef REGAMEDLL_ADD
 	FireTargets("game_round_start", nullptr, nullptr, USE_TOGGLE, 0.0);

--- a/regamedll/dlls/player.cpp
+++ b/regamedll/dlls/player.cpp
@@ -5881,8 +5881,10 @@ int CBasePlayer::Restore(CRestore &restore)
 
 void CBasePlayer::Reset()
 {
-	pev->frags = 0;
-	m_iDeaths = 0;
+	if (!g_bSwappedTeams) {
+		pev->frags = 0;
+		m_iDeaths = 0;
+	}
 
 #ifndef REGAMEDLL_ADD
 	m_iAccount = 0;


### PR DESCRIPTION
swapteams calls sv_restartround 1 which will reset all team & player scores, total rounds played etc, this PR should fix this unintended behaviour.

the best way i could do it is by adding a global boolean.

(sorry for new PR i couldn't git reset --hard the last one I closed because I deleted it before I went to sleep)

Also I tested this properly with swapteams -1, swapteams with no arg, and swapteams with different values, and it worked as intended with the PR. Also ran a workflow for this on my own repo and it passed [all tests](https://github.com/deprale/ReGameDLL_CS/actions/runs/4228715979).