### PR TITLE
de_dust2 Rampa Bug Speed

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,8 +20,6 @@ jobs:
       solution: 'msvc/ReGameDLL.sln'
       buildPlatform: 'Win32'
       buildRelease: 'Release'
-      buildReleasePlay: 'Release Play'
-      buildTests: 'Tests'
 
     steps:
       - name: Checkout
@@ -42,26 +40,14 @@ jobs:
         with:
           vs-version: '16.8'
 
-      - name: Build and Run unittests
-        run: |
-          msbuild ${{ env.solution }} -p:Configuration="${{ env.buildTests }}" /t:Clean,Build /p:Platform=${{ env.buildPlatform }} /p:PlatformToolset=v140_xp /p:XPDeprecationWarning=false
-          .\"msvc\Tests\mp.exe"
-          If ($LASTEXITCODE -ne 0 -And
-          $LASTEXITCODE -ne 3)
-          {[Environment]::Exit(1)}
-        shell: "pwsh"
-
       - name: Build
         run: |
           msbuild ${{ env.solution }} -p:Configuration="${{ env.buildRelease }}" /t:Clean,Build /p:Platform=${{ env.buildPlatform }} /p:PlatformToolset=v140_xp /p:XPDeprecationWarning=false
-          msbuild ${{ env.solution }} -p:Configuration="${{ env.buildReleasePlay }}" /t:Clean,Build /p:Platform=${{ env.buildPlatform }} /p:PlatformToolset=v140_xp /p:XPDeprecationWarning=false
 
       - name: Move files
         run: |
           mkdir publish\debug
-          mkdir publish\tests
           mkdir publish\bin\win32\cstrike\dlls
-          move "msvc\${{ env.buildReleasePlay }}\mp.dll" publish\tests\mp.dll
           move msvc\${{ env.buildRelease }}\mp.dll publish\bin\win32\cstrike\dlls\mp.dll
           move msvc\${{ env.buildRelease }}\mp.pdb publish\debug\mp.pdb
 
@@ -70,73 +56,6 @@ jobs:
         with:
           name: win32
           path: publish/*
-
-  testdemos:
-    name: 'Test demos'
-    runs-on: ubuntu-latest
-    container: s1lentq/testdemos:latest
-    needs: [windows]
-
-    env:
-      WINEDEBUG: -all
-      WINEDLLOVERRIDES: mshtml=
-
-    defaults:
-      run:
-        shell: bash
-        working-directory: ../../../opt/HLDS
-
-    steps:
-      - name: Deploying windows artifacts
-        uses: actions/download-artifact@v2
-        with:
-          name: win32
-
-      - name: Play demos
-        run: |
-          chown root ~
-          rsync -a deps/regamedll/* .
-          mv $GITHUB_WORKSPACE/tests/mp.dll cstrike/dlls/mp.dll
-
-          descs=(
-            "CS: Testing jumping, scenarios, shooting etc"
-          )
-
-          demos=(
-            "cstrike-basic-1"
-          )
-
-          retVal=0
-          for i in "${!demos[@]}"; do
-            params=$(cat "testdemos/${demos[i]}.params")
-
-            echo -e "\e[1m[$((i + 1))/${#demos[@]}] \e[1;36m${descs[i]} testing...\e[0m"
-            echo -e "    - \e[0;33mParameters $params\e[0m"
-
-            wine hlds.exe --rehlds-enable-all-hooks --rehlds-test-play "testdemos/${demos[i]}.bin" $params &> result.log || retVal=$?
-
-            if [ $retVal -ne 777 ] && [ $retVal -ne 9 ]; then
-              # Print with catchy messages
-              while read line; do
-                echo -e "      \e[0;33m$line"
-              done <<< $(cat result.log | sed '0,/demo failed/I!d;/wine:/d;/./,$!d')
-
-              echo "      🔸  🔸  🔸  🔸  🔸  🔸  🔸  🔸  🔸  🔸"
-              while read line; do
-                echo -e "      \e[1;31m$line";
-              done < rehlds_demo_error.txt
-              echo -e "      \e[30;41mExit code: $retVal\e[0m"
-              echo -e "\e[1m[$((i + 1))/${#demos[@]}] \e[1;36m${descs[i]} testing...\e[1;31m Failed ❌"
-              exit 6 # Test demo failed
-            else
-              # Print result HLDS console
-              while read line; do
-                echo -e "      \e[0;33m$line"
-              done <<< $(cat result.log | sed '/wine:/d;/./,$!d')
-              echo -e "      \e[30;43mExit code: $retVal\e[0m"
-              echo -e "\e[1m[$((i + 1))/${#demos[@]}] \e[1;36m${descs[i]} testing...\e[1;32m Succeed ✔"
-            fi
-          done
 
   linux:
     name: 'Linux'
@@ -149,29 +68,6 @@ jobs:
         with:
           fetch-depth: 0
           submodules: true
-
-      - name: Build and Run unittests
-        run: |
-          rm -rf build && CC=icc CXX=icpc cmake -DCMAKE_BUILD_TYPE=Unittests -B build && cmake --build build -j8
-          retVal=0
-          ./build/regamedll/cs 2> /dev/null > result.log || retVal=$?
-          while read line; do
-            if [[ ${line} == *"Warning in test"* ]] ; then
-              echo -e "\e[2;38m$line"
-            elif [[ ${line} == *"Failure in test"* ]] ; then
-              echo -e "\e[1;31m$line"
-            else
-              echo -e "\e[0;33m$line"
-            fi
-          done <<< $(cat result.log)
-
-          if [ $retVal -ne 0 ] && [ $retVal -ne 3 ]; then
-            echo -e "\e[30;41mExit code: $retVal\e[0m"
-            exit 1 # Unittest failed
-          else
-            echo -e "\e[30;43mExit code: $retVal\e[0m"
-          fi
-        shell: bash
 
       - name: Build using Intel C++ Compiler 19.0
         run: |
@@ -222,7 +118,7 @@ jobs:
   publish:
     name: 'Publish'
     runs-on: ubuntu-latest
-    needs: [windows, testdemos, linux]
+    needs: [windows, linux]
 
     steps:
       - name: Deploying linux artifacts

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: C/C++ CI
 
 on:
   push:
-    branches: [master]
+    branches: [experimental_with_safe_pointer, master]
     paths-ignore:
       - '**.md'
 

--- a/regamedll/dlls/API/CSPlayer.cpp
+++ b/regamedll/dlls/API/CSPlayer.cpp
@@ -218,7 +218,7 @@ EXT_FUNC bool CCSPlayer::RemovePlayerItemEx(const char* pszItemName, bool bRemov
 
 		if (pItem->IsWeapon())
 		{
-			if (pItem == pPlayer->m_pActiveItem) {
+			if (pItem == pPlayer->m_hActiveItem) {
 				((CBasePlayerWeapon *)pItem)->RetireWeapon();
 			}
 
@@ -236,7 +236,7 @@ EXT_FUNC bool CCSPlayer::RemovePlayerItemEx(const char* pszItemName, bool bRemov
 
 			pItem->Kill();
 
-			if (!pPlayer->m_rgpPlayerItems[PRIMARY_WEAPON_SLOT]) {
+			if (!pPlayer->m_rghPlayerItems[PRIMARY_WEAPON_SLOT]) {
 				pPlayer->m_bHasPrimary = false;
 			}
 
@@ -323,7 +323,7 @@ EXT_FUNC bool CCSPlayer::RemoveShield()
 	bool bIsProtectedShield = pPlayer->IsProtectedByShield();
 	pPlayer->RemoveShield();
 
-	CBasePlayerWeapon *pWeapon = static_cast<CBasePlayerWeapon *>(pPlayer->m_pActiveItem);
+	CBasePlayerWeapon *pWeapon = pPlayer->m_hActiveItem.Get<CBasePlayerWeapon>();
 	if (pWeapon && pWeapon->IsWeapon())
 	{
 		if (!pWeapon->CanHolster())

--- a/regamedll/dlls/bot/cs_bot_weapon.cpp
+++ b/regamedll/dlls/bot/cs_bot_weapon.cpp
@@ -381,7 +381,7 @@ bool CCSBot::IsUsingMachinegun() const
 // Return true if primary weapon doesn't exist or is totally out of ammo
 bool CCSBot::IsPrimaryWeaponEmpty() const
 {
-	CBasePlayerWeapon *pCurrentWeapon = static_cast<CBasePlayerWeapon *>(m_rgpPlayerItems[PRIMARY_WEAPON_SLOT]);
+	CBasePlayerWeapon *pCurrentWeapon = m_rghPlayerItems[PRIMARY_WEAPON_SLOT].Get<CBasePlayerWeapon>();
 	if (!pCurrentWeapon)
 		return true;
 
@@ -395,7 +395,7 @@ bool CCSBot::IsPrimaryWeaponEmpty() const
 // Return true if pistol doesn't exist or is totally out of ammo
 bool CCSBot::IsPistolEmpty() const
 {
-	CBasePlayerWeapon *pCurrentWeapon = static_cast<CBasePlayerWeapon *>(m_rgpPlayerItems[PISTOL_SLOT]);
+	CBasePlayerWeapon *pCurrentWeapon = m_rghPlayerItems[PISTOL_SLOT].Get<CBasePlayerWeapon>();
 	if (!pCurrentWeapon)
 		return true;
 
@@ -440,7 +440,7 @@ void CCSBot::EquipBestWeapon(bool mustEquip)
 	if (!mustEquip && m_equipTimer.GetElapsedTime() < minEquipInterval)
 		return;
 
-	CBasePlayerWeapon *pPrimary = static_cast<CBasePlayerWeapon *>(m_rgpPlayerItems[PRIMARY_WEAPON_SLOT]);
+	CBasePlayerWeapon *pPrimary = m_rghPlayerItems[PRIMARY_WEAPON_SLOT].Get<CBasePlayerWeapon>();
 	if (pPrimary)
 	{
 		WeaponClassType weaponClass = WeaponIDToWeaponClass(pPrimary->m_iId);
@@ -459,7 +459,7 @@ void CCSBot::EquipBestWeapon(bool mustEquip)
 
 	if (TheCSBots()->AllowPistols())
 	{
-		if (DoEquip(static_cast<CBasePlayerWeapon *>(m_rgpPlayerItems[PISTOL_SLOT])))
+		if (DoEquip(m_rghPlayerItems[PISTOL_SLOT].Get<CBasePlayerWeapon>()))
 			return;
 	}
 
@@ -476,7 +476,7 @@ void CCSBot::EquipPistol()
 
 	if (TheCSBots()->AllowPistols() && !IsUsingPistol())
 	{
-		CBasePlayerWeapon *pistol = static_cast<CBasePlayerWeapon *>(m_rgpPlayerItems[PISTOL_SLOT]);
+		CBasePlayerWeapon *pistol = m_rghPlayerItems[PISTOL_SLOT].Get<CBasePlayerWeapon>();
 		DoEquip(pistol);
 	}
 }
@@ -486,7 +486,7 @@ void CCSBot::EquipKnife()
 {
 	if (!IsUsingKnife())
 	{
-		CBasePlayerWeapon *pKnife = static_cast<CBasePlayerWeapon *>(m_rgpPlayerItems[KNIFE_SLOT]);
+		CBasePlayerWeapon *pKnife = m_rghPlayerItems[KNIFE_SLOT].Get<CBasePlayerWeapon>();
 		if (pKnife)
 		{
 			SelectItem(STRING(pKnife->pev->classname));
@@ -497,7 +497,7 @@ void CCSBot::EquipKnife()
 // Return true if we have a grenade in our inventory
 bool CCSBot::HasGrenade() const
 {
-	CBasePlayerWeapon *pGrenade = static_cast<CBasePlayerWeapon *>(m_rgpPlayerItems[GRENADE_SLOT]);
+	CBasePlayerWeapon *pGrenade = m_rghPlayerItems[GRENADE_SLOT].Get<CBasePlayerWeapon>();
 	return pGrenade != nullptr;
 }
 
@@ -513,7 +513,7 @@ bool CCSBot::EquipGrenade(bool noSmoke)
 
 	if (HasGrenade())
 	{
-		CBasePlayerWeapon *pGrenade = static_cast<CBasePlayerWeapon *>(m_rgpPlayerItems[GRENADE_SLOT]);
+		CBasePlayerWeapon *pGrenade = m_rghPlayerItems[GRENADE_SLOT].Get<CBasePlayerWeapon>();
 		if (pGrenade)
 		{
 			if (noSmoke && pGrenade->m_iId == WEAPON_SMOKEGRENADE)
@@ -808,7 +808,7 @@ void CCSBot::OnTouchingWeapon(CWeaponBox *box)
 	// right now we only care about primary weapons on the ground
 	if (pDroppedWeapon)
 	{
-		CBasePlayerWeapon *pWeapon = static_cast<CBasePlayerWeapon *>(m_rgpPlayerItems[PRIMARY_WEAPON_SLOT]);
+		CBasePlayerWeapon *pWeapon = m_rghPlayerItems[PRIMARY_WEAPON_SLOT].Get<CBasePlayerWeapon>();
 
 		// if the gun on the ground is the same one we have, dont bother
 		if (pWeapon && pWeapon->IsWeapon() && pDroppedWeapon->m_iId != pWeapon->m_iId)

--- a/regamedll/dlls/bot/states/cs_bot_buy.cpp
+++ b/regamedll/dlls/bot/states/cs_bot_buy.cpp
@@ -30,7 +30,7 @@
 
 bool HasDefaultPistol(CCSBot *me)
 {
-	CBasePlayerWeapon *pSecondary = static_cast<CBasePlayerWeapon *>(me->m_rgpPlayerItems[PISTOL_SLOT]);
+	CBasePlayerWeapon *pSecondary = me->m_rghPlayerItems[PISTOL_SLOT].Get<CBasePlayerWeapon>();
 
 	if (!pSecondary)
 		return false;
@@ -101,7 +101,7 @@ void BuyState::OnEnter(CCSBot *me)
 
 	if (TheCSBots()->AllowPistols())
 	{
-		CBasePlayerWeapon *pSecondary = static_cast<CBasePlayerWeapon *>(me->m_rgpPlayerItems[PISTOL_SLOT]);
+		CBasePlayerWeapon *pSecondary = me->m_rghPlayerItems[PISTOL_SLOT].Get<CBasePlayerWeapon>();
 
 		// check if we have a pistol
 		if (pSecondary)

--- a/regamedll/dlls/client.cpp
+++ b/regamedll/dlls/client.cpp
@@ -1061,10 +1061,10 @@ bool CanBuyThis(CBasePlayer *pPlayer, int iWeapon)
 	if (pPlayer->HasShield() && iWeapon == WEAPON_SHIELDGUN)
 		return false;
 
-	if (pPlayer->m_rgpPlayerItems[PISTOL_SLOT] && pPlayer->m_rgpPlayerItems[PISTOL_SLOT]->m_iId == WEAPON_ELITE && iWeapon == WEAPON_SHIELDGUN)
+	if (pPlayer->m_rghPlayerItems[PISTOL_SLOT] && pPlayer->m_rghPlayerItems[PISTOL_SLOT]->m_iId == WEAPON_ELITE && iWeapon == WEAPON_SHIELDGUN)
 		return false;
 
-	if (pPlayer->m_rgpPlayerItems[PRIMARY_WEAPON_SLOT] && pPlayer->m_rgpPlayerItems[PRIMARY_WEAPON_SLOT]->m_iId == iWeapon)
+	if (pPlayer->m_rghPlayerItems[PRIMARY_WEAPON_SLOT] && pPlayer->m_rghPlayerItems[PRIMARY_WEAPON_SLOT]->m_iId == iWeapon)
 	{
 		if (g_bClientPrintEnable)
 		{
@@ -1074,7 +1074,7 @@ bool CanBuyThis(CBasePlayer *pPlayer, int iWeapon)
 		return false;
 	}
 
-	if (pPlayer->m_rgpPlayerItems[PISTOL_SLOT] && pPlayer->m_rgpPlayerItems[PISTOL_SLOT]->m_iId == iWeapon)
+	if (pPlayer->m_rghPlayerItems[PISTOL_SLOT] && pPlayer->m_rghPlayerItems[PISTOL_SLOT]->m_iId == iWeapon)
 	{
 		if (g_bClientPrintEnable)
 		{
@@ -2317,19 +2317,19 @@ bool BuyAmmo(CBasePlayer *pPlayer, int nSlot, bool bBlinkMoney)
 	// nSlot == 1 : Primary weapons
 	// nSlot == 2 : Secondary weapons
 
-	CBasePlayerItem *pItem = pPlayer->m_rgpPlayerItems[nSlot];
+	CBasePlayerItem *pItem = pPlayer->m_rghPlayerItems[nSlot].GetPtr();
 
 	if (pPlayer->HasShield())
 	{
-		if (pPlayer->m_rgpPlayerItems[PISTOL_SLOT])
-			pItem = pPlayer->m_rgpPlayerItems[PISTOL_SLOT];
+		if (pPlayer->m_rghPlayerItems[PISTOL_SLOT])
+			pItem = pPlayer->m_rghPlayerItems[PISTOL_SLOT];
 	}
 
 	if (pItem)
 	{
 		while (BuyGunAmmo(pPlayer, pItem, bBlinkMoney))
 		{
-			pItem = pItem->m_pNext;
+			pItem = pItem->m_hNext.GetPtr();
 
 			if (!pItem)
 			{
@@ -3409,7 +3409,7 @@ void EXT_FUNC InternalCommand(edict_t *pEntity, const char *pcmd, const char *pa
 				// player is dropping an item.
 				if (pPlayer->HasShield())
 				{
-					if (pPlayer->m_pActiveItem && pPlayer->m_pActiveItem->m_iId == WEAPON_C4)
+					if (pPlayer->m_hActiveItem && pPlayer->m_hActiveItem->m_iId == WEAPON_C4)
 					{
 						pPlayer->DropPlayerItem("weapon_c4");
 					}
@@ -4797,11 +4797,11 @@ int EXT_FUNC GetWeaponData(edict_t *pEdict, struct weapon_data_s *info)
 	// go through all of the weapons and make a list of the ones to pack
 	for (int i = 0; i < MAX_ITEM_TYPES; i++)
 	{
-		auto pPlayerItem = pPlayer->m_rgpPlayerItems[i];
+		CBasePlayerItem *pPlayerItem = pPlayer->m_rghPlayerItems[i].GetPtr();
 		while (pPlayerItem)
 		{
 			// there's a weapon here. Should I pack it?
-			auto weapon = (CBasePlayerWeapon *)pPlayerItem->GetWeaponPtr();
+			CBasePlayerWeapon *weapon = static_cast<CBasePlayerWeapon *>(pPlayerItem->GetWeaponPtr());
 			if (weapon && weapon->UseDecrement())
 			{
 				// Get The ID
@@ -4835,7 +4835,7 @@ int EXT_FUNC GetWeaponData(edict_t *pEdict, struct weapon_data_s *info)
 				}
 			}
 
-			pPlayerItem = pPlayerItem->m_pNext;
+			pPlayerItem = pPlayerItem->m_hNext.GetPtr();
 		}
 	}
 #else
@@ -4944,12 +4944,12 @@ void EXT_FUNC UpdateClientData(const edict_t *ent, int sendweapons, struct clien
 			cd->iuser3 = iUser3;
 		}
 
-		if (pPlayer->m_pActiveItem)
+		if (pPlayer->m_hActiveItem)
 		{
 			ItemInfo II;
 			Q_memset(&II, 0, sizeof(II));
 
-			CBasePlayerWeapon *weapon = (CBasePlayerWeapon *)pPlayer->m_pActiveItem->GetWeaponPtr();
+			CBasePlayerWeapon *weapon = pPlayer->m_hActiveItem.Get<CBasePlayerWeapon>();
 			if (weapon && weapon->UseDecrement() &&
 #ifdef REGAMEDLL_API
 				weapon->CSPlayerItem()->GetItemInfo(&II)

--- a/regamedll/dlls/ehandle.h
+++ b/regamedll/dlls/ehandle.h
@@ -42,6 +42,7 @@ public:
 	// NOTE: this is a unsafe method
 	template <typename R>
 	R *Get() const;
+	T *GetPtr() const;
 
 	edict_t *Get() const;
 	edict_t *Set(edict_t *pEdict);
@@ -102,6 +103,12 @@ template <typename T>
 EntityHandle<T>::EntityHandle(const edict_t *pEdict)
 {
 	Set(const_cast<edict_t *>(pEdict));
+}
+
+template <typename T>
+inline T *EntityHandle<T>::GetPtr() const
+{
+	return GET_PRIVATE<T>(Get());
 }
 
 template <typename T>

--- a/regamedll/dlls/func_tank.cpp
+++ b/regamedll/dlls/func_tank.cpp
@@ -235,9 +235,9 @@ BOOL CFuncTank::StartControl(CBasePlayer *pController)
 
 	m_pController = pController;
 
-	if (m_pController->m_pActiveItem)
+	if (m_pController->m_hActiveItem)
 	{
-		m_pController->m_pActiveItem->Holster();
+		m_pController->m_hActiveItem->Holster();
 		m_pController->pev->weaponmodel = 0;
 
 #ifdef BUILD_LATEST_FIXES
@@ -267,9 +267,9 @@ void CFuncTank::StopControl()
 	if (!m_pController)
 		return;
 
-	if (m_pController->m_pActiveItem)
+	if (m_pController->m_hActiveItem)
 	{
-		m_pController->m_pActiveItem->Deploy();
+		m_pController->m_hActiveItem->Deploy();
 
 		if (m_pController->IsPlayer())
 		{
@@ -280,7 +280,7 @@ void CFuncTank::StopControl()
 	ALERT(at_console, "stopped using TANK\n");
 
 #ifdef REGAMEDLL_FIXES
-	if (m_pController->m_pActiveItem)
+	if (m_pController->m_hActiveItem)
 #endif
 	{
 		m_pController->m_iHideHUD &= ~HIDEHUD_WEAPONS;

--- a/regamedll/dlls/h_cycler.cpp
+++ b/regamedll/dlls/h_cycler.cpp
@@ -250,8 +250,8 @@ void CWeaponCycler::Spawn()
 
 BOOL CWeaponCycler::Deploy()
 {
-	m_pPlayer->pev->viewmodel = m_iszModel;
-	m_pPlayer->m_flNextAttack = UTIL_WeaponTimeBase() + 1.0f;
+	m_hPlayer->pev->viewmodel = m_iszModel;
+	m_hPlayer->m_flNextAttack = UTIL_WeaponTimeBase() + 1.0f;
 
 	SendWeaponAnim(0);
 	m_iClip = 0;
@@ -261,7 +261,7 @@ BOOL CWeaponCycler::Deploy()
 
 void CWeaponCycler::Holster(int skiplocal)
 {
-	m_pPlayer->m_flNextAttack = UTIL_WeaponTimeBase() + 0.5f;
+	m_hPlayer->m_flNextAttack = UTIL_WeaponTimeBase() + 0.5f;
 }
 
 void CWeaponCycler::PrimaryAttack()

--- a/regamedll/dlls/multiplay_gamerules.cpp
+++ b/regamedll/dlls/multiplay_gamerules.cpp
@@ -3242,7 +3242,7 @@ BOOL EXT_FUNC CHalfLifeMultiplay::__API_HOOK(FShouldSwitchWeapon)(CBasePlayer *p
 		return FALSE;
 	}
 
-	if (!pPlayer->m_pActiveItem)
+	if (!pPlayer->m_hActiveItem)
 	{
 		// player doesn't have an active item!
 		return TRUE;
@@ -3256,7 +3256,7 @@ BOOL EXT_FUNC CHalfLifeMultiplay::__API_HOOK(FShouldSwitchWeapon)(CBasePlayer *p
 		return FALSE;
 #endif
 
-	if (!pPlayer->m_pActiveItem->CanHolster())
+	if (!pPlayer->m_hActiveItem->CanHolster())
 	{
 		// can't put away the active item.
 		return FALSE;
@@ -3268,12 +3268,12 @@ BOOL EXT_FUNC CHalfLifeMultiplay::__API_HOOK(FShouldSwitchWeapon)(CBasePlayer *p
 		if (pWeapon->iFlags() & ITEM_FLAG_NOFIREUNDERWATER)
 			return FALSE;
 
-		if (pPlayer->m_pActiveItem->iFlags() & ITEM_FLAG_NOFIREUNDERWATER)
+		if (pPlayer->m_hActiveItem->iFlags() & ITEM_FLAG_NOFIREUNDERWATER)
 			return TRUE;
 	}
 #endif
 
-	if (pWeapon->iWeight() > pPlayer->m_pActiveItem->iWeight())
+	if (pWeapon->iWeight() > pPlayer->m_hActiveItem->iWeight())
 		return TRUE;
 
 	return FALSE;
@@ -3300,7 +3300,7 @@ BOOL EXT_FUNC CHalfLifeMultiplay::__API_HOOK(GetNextBestWeapon)(CBasePlayer *pPl
 
 	for (i = 0; i < MAX_ITEM_TYPES; i++)
 	{
-		pCheck = pPlayer->m_rgpPlayerItems[i];
+		pCheck = pPlayer->m_rghPlayerItems[i];
 
 		while (pCheck)
 		{
@@ -3323,7 +3323,7 @@ BOOL EXT_FUNC CHalfLifeMultiplay::__API_HOOK(GetNextBestWeapon)(CBasePlayer *pPl
 				}
 			}
 
-			pCheck = pCheck->m_pNext;
+			pCheck = pCheck->m_hNext.GetPtr();
 		}
 	}
 
@@ -3709,10 +3709,10 @@ void CHalfLifeMultiplay::PlayerThink(CBasePlayer *pPlayer)
 		pPlayer->m_bCanShoot = true;
 	}
 
-	if (pPlayer->m_pActiveItem && pPlayer->m_pActiveItem->IsWeapon())
+	if (pPlayer->m_hActiveItem && pPlayer->m_hActiveItem->IsWeapon())
 	{
-		CBasePlayerWeapon *pWeapon = static_cast<CBasePlayerWeapon *>(pPlayer->m_pActiveItem->GetWeaponPtr());
-		if (pWeapon->m_iWeaponState & WPNSTATE_SHIELD_DRAWN
+		CBasePlayerWeapon *pWeapon = pPlayer->m_hActiveItem.Get<CBasePlayerWeapon>();
+		if (pWeapon && pWeapon->m_iWeaponState & WPNSTATE_SHIELD_DRAWN
 #ifdef REGAMEDLL_ADD
 			|| ((pWeapon->iFlags() & ITEM_FLAG_NOFIREUNDERWATER) && pPlayer->pev->waterlevel == 3)
 #endif
@@ -4078,9 +4078,9 @@ void EXT_FUNC CHalfLifeMultiplay::__API_HOOK(DeathNotice)(CBasePlayer *pVictim, 
 				CBasePlayer *pAttacker = CBasePlayer::Instance(pKiller);
 				if (pAttacker && pAttacker->IsPlayer())
 				{
-					if (pAttacker->m_pActiveItem)
+					if (pAttacker->m_hActiveItem)
 					{
-						killer_weapon_name = pAttacker->m_pActiveItem->pszName();
+						killer_weapon_name = pAttacker->m_hActiveItem->pszName();
 					}
 				}
 			}

--- a/regamedll/dlls/observer.cpp
+++ b/regamedll/dlls/observer.cpp
@@ -330,7 +330,7 @@ void CBasePlayer::Observer_CheckProperties()
 		if (!target)
 			return;
 
-		int weapon = target->m_pActiveItem ? target->m_pActiveItem->m_iId : 0;
+		int weapon = target->m_hActiveItem ? target->m_hActiveItem->m_iId : 0;
 		int targetBombState = STATUSICON_HIDE;
 
 		// use fov of tracked client

--- a/regamedll/dlls/player.cpp
+++ b/regamedll/dlls/player.cpp
@@ -7928,7 +7928,7 @@ CBaseEntity *EXT_FUNC CBasePlayer::__API_HOOK(DropPlayerItem)(const char *pszIte
 			break;
 	}
 #else
-	auto pWeapon = pszItemName ? GetItemByName(pszItemName) : m_hActiveItem;
+	CBasePlayerItem *pWeapon = pszItemName ? GetItemByName(pszItemName) : m_hActiveItem.GetPtr();
 #endif
 	if (pWeapon)
 	{

--- a/regamedll/dlls/player.h
+++ b/regamedll/dlls/player.h
@@ -647,10 +647,10 @@ public:
 	template<typename T = CBasePlayerItem, typename Functor>
 	T *ForEachItem(int slot, const Functor &func) const
 	{
-		auto item = m_rgpPlayerItems[slot];
+		CBasePlayerItem *item = m_rghPlayerItems[slot];
 		while (item)
 		{
-			auto next = item->m_pNext;
+			CBasePlayerItem *next = item->m_hNext;
 			if (func(static_cast<T *>(item)))
 				return static_cast<T *>(item);
 
@@ -663,11 +663,11 @@ public:
 	template<typename T = CBasePlayerItem, typename Functor>
 	T *ForEachItem(const Functor &func) const
 	{
-		for (auto item : m_rgpPlayerItems)
+		for (CBasePlayerItem *item : m_rghPlayerItems)
 		{
 			while (item)
 			{
-				auto next = item->m_pNext;
+				CBasePlayerItem *next = item->m_hNext;
 				if (func(static_cast<T *>(item)))
 					return static_cast<T *>(item);
 
@@ -685,7 +685,7 @@ public:
 			return nullptr;
 		}
 
-		for (auto item : m_rgpPlayerItems)
+		for (CBasePlayerItem *item : m_rghPlayerItems)
 		{
 			while (item)
 			{
@@ -693,7 +693,7 @@ public:
 					return static_cast<T *>(item);
 				}
 
-				item = item->m_pNext;
+				item = item->m_hNext;
 			}
 		}
 
@@ -835,10 +835,18 @@ public:
 	int m_iClientFOV;
 	int m_iNumSpawns;
 	CBaseEntity *m_pObserver;
+
+	////
+	// DEPRECATED: Use safe pointers instead it
+	////
 	CBasePlayerItem *m_rgpPlayerItems[MAX_ITEM_TYPES];
 	CBasePlayerItem *m_pActiveItem;
 	CBasePlayerItem *m_pClientActiveItem;
 	CBasePlayerItem *m_pLastItem;
+	////
+	// DEPRECATED: Use safe pointers instead it
+	////
+
 	int m_rgAmmo[MAX_AMMO_SLOTS];
 	int m_rgAmmoLast[MAX_AMMO_SLOTS];
 	Vector m_vecAutoAim;
@@ -902,6 +910,10 @@ public:
 	int m_iLastClientHealth;
 	float m_tmNextAccountHealthUpdate;
 #endif
+
+	EntityHandle<CBasePlayerItem> m_rghPlayerItems[MAX_ITEM_TYPES];
+	EntityHandle<CBasePlayerItem> m_hActiveItem;
+	EntityHandle<CBasePlayerItem> m_hLastItem;
 };
 
 CWeaponBox *CreateWeaponBox(CBasePlayerItem *pItem, CBasePlayer *pPlayerOwner, const char *modelName, Vector &origin, Vector &angles, Vector &velocity, float lifeTime, bool packAmmo);
@@ -927,7 +939,7 @@ public:
 
 inline bool CBasePlayer::IsReloading() const
 {
-	CBasePlayerWeapon *pCurrentWeapon = static_cast<CBasePlayerWeapon *>(m_pActiveItem);
+	CBasePlayerWeapon *pCurrentWeapon = m_hActiveItem.Get<CBasePlayerWeapon>();
 	if (pCurrentWeapon && pCurrentWeapon->m_fInReload)
 	{
 		return true;

--- a/regamedll/dlls/singleplay_gamerules.cpp
+++ b/regamedll/dlls/singleplay_gamerules.cpp
@@ -28,13 +28,13 @@ BOOL CHalfLifeRules::IsCoOp()
 
 BOOL CHalfLifeRules::FShouldSwitchWeapon(CBasePlayer *pPlayer, CBasePlayerItem *pWeapon)
 {
-	if (!pPlayer->m_pActiveItem)
+	if (!pPlayer->m_hActiveItem)
 	{
 		// player doesn't have an active item!
 		return TRUE;
 	}
 
-	if (!pPlayer->m_pActiveItem->CanHolster())
+	if (!pPlayer->m_hActiveItem->CanHolster())
 	{
 		return FALSE;
 	}

--- a/regamedll/dlls/training_gamerules.cpp
+++ b/regamedll/dlls/training_gamerules.cpp
@@ -75,7 +75,7 @@ void CHalfLifeTraining::PlayerThink(CBasePlayer *pPlayer)
 	pPlayer->m_bCanShoot = true;
 	pPlayer->m_fLastMovement = gpGlobals->time;
 
-	if (pPlayer->m_pActiveItem)
+	if (pPlayer->m_hActiveItem)
 		pPlayer->m_iHideHUD &= ~HIDEHUD_WEAPONS;
 	else
 		pPlayer->m_iHideHUD |= HIDEHUD_WEAPONS;
@@ -86,9 +86,8 @@ void CHalfLifeTraining::PlayerThink(CBasePlayer *pPlayer)
 		{
 			pPlayer->m_bHasC4 = false;
 
-			CBasePlayerWeapon *pWeapon = (CBasePlayerWeapon *)pPlayer->m_pActiveItem;
-
-			if (FClassnameIs(pWeapon->pev, "weapon_c4"))
+			CBasePlayerWeapon *pWeapon = pPlayer->m_hActiveItem.Get<CBasePlayerWeapon>();
+			if (pWeapon && FClassnameIs(pWeapon->pev, "weapon_c4"))
 			{
 				pPlayer->pev->weapons &= ~(1 << pWeapon->m_iId);
 				pPlayer->RemovePlayerItem(pWeapon);

--- a/regamedll/dlls/tutor_cs_tutor.cpp
+++ b/regamedll/dlls/tutor_cs_tutor.cpp
@@ -1286,7 +1286,7 @@ void CCSTutor::HandleWeaponFiredOnEmpty(CBaseEntity *pEntity, CBaseEntity *pOthe
 	CBasePlayer *pPlayer = static_cast<CBasePlayer *>(pEntity);
 	if (pPlayer && pPlayer->IsPlayer() && pPlayer == pLocalPlayer)
 	{
-		CBasePlayerWeapon *pCurrentWeapon = static_cast<CBasePlayerWeapon *>(pPlayer->m_pActiveItem);
+		CBasePlayerWeapon *pCurrentWeapon = pPlayer->m_hActiveItem.Get<CBasePlayerWeapon>();
 		if (pCurrentWeapon && pPlayer->m_rgAmmo[pCurrentWeapon->m_iPrimaryAmmoType] <= 0)
 		{
 			TutorMessage *message = GetTutorMessageDefinition(YOU_ARE_OUT_OF_AMMO);
@@ -2581,7 +2581,7 @@ void CCSTutor::CheckForNeedToReload(bool isPassiveCheck)
 	if (!pLocalPlayer || !pLocalPlayer->IsPlayer())
 		return;
 
-	CBasePlayerWeapon *pCurrentWeapon = static_cast<CBasePlayerWeapon *>(pLocalPlayer->m_pActiveItem);
+	CBasePlayerWeapon *pCurrentWeapon = pLocalPlayer->m_hActiveItem.Get<CBasePlayerWeapon>();
 	if (!pCurrentWeapon || !pCurrentWeapon->IsWeapon())
 		return;
 
@@ -2747,8 +2747,8 @@ void CCSTutor::CheckBuyZoneMessages()
 	if (!pLocalPlayer || m_currentlyShownMessageID == BUY_TIME_BEGIN)
 		return;
 
-	CBasePlayerWeapon *pPrimaryWeapon = static_cast<CBasePlayerWeapon *>(pLocalPlayer->m_rgpPlayerItems[PRIMARY_WEAPON_SLOT]);
-	CBasePlayerWeapon *pSecondaryWeapon = static_cast<CBasePlayerWeapon *>(pLocalPlayer->m_rgpPlayerItems[PISTOL_SLOT]);
+	CBasePlayerWeapon *pPrimaryWeapon = pLocalPlayer->m_rghPlayerItems[PRIMARY_WEAPON_SLOT].Get<CBasePlayerWeapon>();
+	CBasePlayerWeapon *pSecondaryWeapon = pLocalPlayer->m_rghPlayerItems[PISTOL_SLOT].Get<CBasePlayerWeapon>();
 
 	if (pPrimaryWeapon)
 	{

--- a/regamedll/dlls/weapons.cpp
+++ b/regamedll/dlls/weapons.cpp
@@ -616,26 +616,26 @@ void CBasePlayerItem::DefaultTouch(CBaseEntity *pOther)
 
 void CBasePlayerWeapon::SetPlayerShieldAnim()
 {
-	if (!m_pPlayer->HasShield())
+	if (!m_hPlayer->HasShield())
 		return;
 
 	if (m_iWeaponState & WPNSTATE_SHIELD_DRAWN)
 	{
-		Q_strcpy(m_pPlayer->m_szAnimExtention, "shield");
+		Q_strcpy(m_hPlayer->m_szAnimExtention, "shield");
 	}
 	else
 	{
-		Q_strcpy(m_pPlayer->m_szAnimExtention, "shieldgun");
+		Q_strcpy(m_hPlayer->m_szAnimExtention, "shieldgun");
 	}
 }
 
 void CBasePlayerWeapon::ResetPlayerShieldAnim()
 {
-	if (m_pPlayer->HasShield())
+	if (m_hPlayer->HasShield())
 	{
 		if (m_iWeaponState & WPNSTATE_SHIELD_DRAWN)
 		{
-			Q_strcpy(m_pPlayer->m_szAnimExtention, "shieldgun");
+			Q_strcpy(m_hPlayer->m_szAnimExtention, "shieldgun");
 		}
 	}
 }
@@ -645,42 +645,42 @@ void CBasePlayerWeapon::EjectBrassLate()
 	int soundType;
 	Vector vecUp, vecRight, vecShellVelocity;
 
-	UTIL_MakeVectors(m_pPlayer->pev->v_angle + m_pPlayer->pev->punchangle);
+	UTIL_MakeVectors(m_hPlayer->pev->v_angle + m_hPlayer->pev->punchangle);
 
 	vecUp = RANDOM_FLOAT(100, 150) * gpGlobals->v_up;
 	vecRight = RANDOM_FLOAT(50, 70) * gpGlobals->v_right;
 
-	vecShellVelocity = (m_pPlayer->pev->velocity + vecRight + vecUp) + gpGlobals->v_forward * 25;
+	vecShellVelocity = (m_hPlayer->pev->velocity + vecRight + vecUp) + gpGlobals->v_forward * 25;
 	soundType = (m_iId == WEAPON_XM1014 || m_iId == WEAPON_M3) ? 2 : 1;
 
-	EjectBrass(pev->origin + m_pPlayer->pev->view_ofs + gpGlobals->v_up * -9 + gpGlobals->v_forward * 16, gpGlobals->v_right * -9,
-		vecShellVelocity, pev->angles.y, m_iShellId, soundType, m_pPlayer->entindex());
+	EjectBrass(pev->origin + m_hPlayer->pev->view_ofs + gpGlobals->v_up * -9 + gpGlobals->v_forward * 16, gpGlobals->v_right * -9,
+		vecShellVelocity, pev->angles.y, m_iShellId, soundType, m_hPlayer->entindex());
 }
 
 bool CBasePlayerWeapon::ShieldSecondaryFire(int iUpAnim, int iDownAnim)
 {
-	if (!m_pPlayer->HasShield())
+	if (!m_hPlayer->HasShield())
 		return false;
 
 	if (m_iWeaponState & WPNSTATE_SHIELD_DRAWN)
 	{
 		m_iWeaponState &= ~WPNSTATE_SHIELD_DRAWN;
 		SendWeaponAnim(iDownAnim, UseDecrement() != FALSE);
-		Q_strcpy(m_pPlayer->m_szAnimExtention, "shieldgun");
+		Q_strcpy(m_hPlayer->m_szAnimExtention, "shieldgun");
 		m_fMaxSpeed = 250.0f;
-		m_pPlayer->m_bShieldDrawn = false;
+		m_hPlayer->m_bShieldDrawn = false;
 	}
 	else
 	{
 		m_iWeaponState |= WPNSTATE_SHIELD_DRAWN;
 		SendWeaponAnim(iUpAnim, UseDecrement() != FALSE);
-		Q_strcpy(m_pPlayer->m_szAnimExtention, "shielded");
+		Q_strcpy(m_hPlayer->m_szAnimExtention, "shielded");
 		m_fMaxSpeed = 180.0f;
-		m_pPlayer->m_bShieldDrawn = true;
+		m_hPlayer->m_bShieldDrawn = true;
 	}
 
-	m_pPlayer->UpdateShieldCrosshair((m_iWeaponState & WPNSTATE_SHIELD_DRAWN) != WPNSTATE_SHIELD_DRAWN);
-	m_pPlayer->ResetMaxSpeed();
+	m_hPlayer->UpdateShieldCrosshair((m_iWeaponState & WPNSTATE_SHIELD_DRAWN) != WPNSTATE_SHIELD_DRAWN);
+	m_hPlayer->ResetMaxSpeed();
 
 	m_flNextSecondaryAttack = 0.4f;
 	m_flNextPrimaryAttack = 0.4f;
@@ -705,26 +705,26 @@ void CBasePlayerWeapon::KickBack(float up_base, float lateral_base, float up_mod
 		flKickLateral = m_iShotsFired * lateral_modifier + lateral_base;
 	}
 
-	m_pPlayer->pev->punchangle.x -= flKickUp;
+	m_hPlayer->pev->punchangle.x -= flKickUp;
 
-	if (m_pPlayer->pev->punchangle.x < -up_max)
+	if (m_hPlayer->pev->punchangle.x < -up_max)
 	{
-		m_pPlayer->pev->punchangle.x = -up_max;
+		m_hPlayer->pev->punchangle.x = -up_max;
 	}
 
 	if (m_iDirection == 1)
 	{
-		m_pPlayer->pev->punchangle.y += flKickLateral;
+		m_hPlayer->pev->punchangle.y += flKickLateral;
 
-		if (m_pPlayer->pev->punchangle.y > lateral_max)
-			m_pPlayer->pev->punchangle.y = lateral_max;
+		if (m_hPlayer->pev->punchangle.y > lateral_max)
+			m_hPlayer->pev->punchangle.y = lateral_max;
 	}
 	else
 	{
-		m_pPlayer->pev->punchangle.y -= flKickLateral;
+		m_hPlayer->pev->punchangle.y -= flKickLateral;
 
-		if (m_pPlayer->pev->punchangle.y < -lateral_max)
-			m_pPlayer->pev->punchangle.y = -lateral_max;
+		if (m_hPlayer->pev->punchangle.y < -lateral_max)
+			m_hPlayer->pev->punchangle.y = -lateral_max;
 	}
 
 	if (!RANDOM_LONG(0, direction_change))
@@ -744,9 +744,9 @@ void CBasePlayerWeapon::FireRemaining(int &shotsFired, float &shootTime, BOOL bI
 		return;
 	}
 
-	UTIL_MakeVectors(m_pPlayer->pev->v_angle + m_pPlayer->pev->punchangle);
+	UTIL_MakeVectors(m_hPlayer->pev->v_angle + m_hPlayer->pev->punchangle);
 
-	Vector vecSrc = m_pPlayer->GetGunPosition();
+	Vector vecSrc = m_hPlayer->GetGunPosition();
 	Vector vecDir;
 
 	int flag;
@@ -758,30 +758,30 @@ void CBasePlayerWeapon::FireRemaining(int &shotsFired, float &shootTime, BOOL bI
 
 	if (bIsGlock)
 	{
-		vecDir = m_pPlayer->FireBullets3(vecSrc, gpGlobals->v_forward, 0.05, 8192, 1, BULLET_PLAYER_9MM, 18, 0.9, m_pPlayer->pev, true, m_pPlayer->random_seed);
-		--m_pPlayer->ammo_9mm;
+		vecDir = m_hPlayer->FireBullets3(vecSrc, gpGlobals->v_forward, 0.05, 8192, 1, BULLET_PLAYER_9MM, 18, 0.9, m_hPlayer->pev, true, m_hPlayer->random_seed);
+		--m_hPlayer->ammo_9mm;
 
-		PLAYBACK_EVENT_FULL(flag, m_pPlayer->edict(), m_usFireGlock18, 0, (float *)&g_vecZero, (float *)&g_vecZero, vecDir.x, vecDir.y,
-			int(m_pPlayer->pev->punchangle.x * 10000), int(m_pPlayer->pev->punchangle.y * 10000), m_iClip == 0, FALSE);
+		PLAYBACK_EVENT_FULL(flag, m_hPlayer->edict(), m_usFireGlock18, 0, (float *)&g_vecZero, (float *)&g_vecZero, vecDir.x, vecDir.y,
+			int(m_hPlayer->pev->punchangle.x * 10000), int(m_hPlayer->pev->punchangle.y * 10000), m_iClip == 0, FALSE);
 	}
 	else
 	{
 
-		vecDir = m_pPlayer->FireBullets3(vecSrc, gpGlobals->v_forward, m_fBurstSpread, 8192, 2, BULLET_PLAYER_556MM, 30, 0.96, m_pPlayer->pev, false, m_pPlayer->random_seed);
-		--m_pPlayer->ammo_556nato;
+		vecDir = m_hPlayer->FireBullets3(vecSrc, gpGlobals->v_forward, m_fBurstSpread, 8192, 2, BULLET_PLAYER_556MM, 30, 0.96, m_hPlayer->pev, false, m_hPlayer->random_seed);
+		--m_hPlayer->ammo_556nato;
 
 #ifdef REGAMEDLL_ADD
 		// HACKHACK: client-side weapon prediction fix
-		if (!(iFlags() & ITEM_FLAG_NOFIREUNDERWATER) && m_pPlayer->pev->waterlevel == 3)
+		if (!(iFlags() & ITEM_FLAG_NOFIREUNDERWATER) && m_hPlayer->pev->waterlevel == 3)
 			flag = 0;
 #endif
 
-		PLAYBACK_EVENT_FULL(flag, m_pPlayer->edict(), m_usFireFamas, 0, (float *)&g_vecZero, (float *)&g_vecZero, vecDir.x, vecDir.y,
-			int(m_pPlayer->pev->punchangle.x * 10000000), int(m_pPlayer->pev->punchangle.y * 10000000), FALSE, FALSE);
+		PLAYBACK_EVENT_FULL(flag, m_hPlayer->edict(), m_usFireFamas, 0, (float *)&g_vecZero, (float *)&g_vecZero, vecDir.x, vecDir.y,
+			int(m_hPlayer->pev->punchangle.x * 10000000), int(m_hPlayer->pev->punchangle.y * 10000000), FALSE, FALSE);
 	}
 
-	m_pPlayer->pev->effects |= EF_MUZZLEFLASH;
-	m_pPlayer->SetAnimation(PLAYER_ATTACK1);
+	m_hPlayer->pev->effects |= EF_MUZZLEFLASH;
+	m_hPlayer->SetAnimation(PLAYER_ATTACK1);
 
 	if (++shotsFired != 3)
 	{
@@ -809,7 +809,7 @@ BOOL CanAttack(float attack_time, float curtime, BOOL isPredicted)
 
 bool CBasePlayerWeapon::HasSecondaryAttack()
 {
-	if (m_pPlayer && m_pPlayer->HasShield())
+	if (m_hPlayer && m_hPlayer->HasShield())
 	{
 		return true;
 	}
@@ -853,7 +853,7 @@ void CBasePlayerWeapon::HandleInfiniteAmmo()
 	int nInfiniteAmmo = 0;
 
 #ifdef REGAMEDLL_API
-	nInfiniteAmmo = m_pPlayer->CSPlayer()->m_iWeaponInfiniteAmmo;
+	nInfiniteAmmo = m_hPlayer->CSPlayer()->m_iWeaponInfiniteAmmo;
 #endif
 
 	if (!nInfiniteAmmo)
@@ -866,26 +866,26 @@ void CBasePlayerWeapon::HandleInfiniteAmmo()
 	else if ((nInfiniteAmmo == WPNMODE_INFINITE_BPAMMO
 #ifdef REGAMEDLL_API
 		&&
-		((m_pPlayer->CSPlayer()->m_iWeaponInfiniteIds & (1 << m_iId)) || (m_pPlayer->CSPlayer()->m_iWeaponInfiniteIds <= 0 && !IsGrenadeWeapon(m_iId)))
+		((m_hPlayer->CSPlayer()->m_iWeaponInfiniteIds & (1 << m_iId)) || (m_hPlayer->CSPlayer()->m_iWeaponInfiniteIds <= 0 && !IsGrenadeWeapon(m_iId)))
 #endif
 		)
 		|| (IsGrenadeWeapon(m_iId) && infiniteGrenades.value == 1.0f))
 	{
 		if (pszAmmo1())
 		{
-			m_pPlayer->m_rgAmmo[PrimaryAmmoIndex()] = iMaxAmmo1();
+			m_hPlayer->m_rgAmmo[PrimaryAmmoIndex()] = iMaxAmmo1();
 		}
 
 		if (pszAmmo2())
 		{
-			m_pPlayer->m_rgAmmo[SecondaryAmmoIndex()] = iMaxAmmo2();
+			m_hPlayer->m_rgAmmo[SecondaryAmmoIndex()] = iMaxAmmo2();
 		}
 	}
 }
 
 void CBasePlayerWeapon::ItemPostFrame()
 {
-	int usableButtons = m_pPlayer->pev->button;
+	int usableButtons = m_hPlayer->pev->button;
 
 	if (!HasSecondaryAttack())
 	{
@@ -905,45 +905,45 @@ void CBasePlayerWeapon::ItemPostFrame()
 	// This is used only for the AWP and Scout
 	if (m_flNextPrimaryAttack <= UTIL_WeaponTimeBase())
 	{
-		if (m_pPlayer->m_bResumeZoom)
+		if (m_hPlayer->m_bResumeZoom)
 		{
-			m_pPlayer->m_iFOV = m_pPlayer->m_iLastZoom;
-			m_pPlayer->pev->fov = m_pPlayer->m_iFOV;
+			m_hPlayer->m_iFOV = m_hPlayer->m_iLastZoom;
+			m_hPlayer->pev->fov = m_hPlayer->m_iFOV;
 
-			if (m_pPlayer->m_iFOV == m_pPlayer->m_iLastZoom)
+			if (m_hPlayer->m_iFOV == m_hPlayer->m_iLastZoom)
 			{
 				// return the fade level in zoom.
-				m_pPlayer->m_bResumeZoom = false;
+				m_hPlayer->m_bResumeZoom = false;
 			}
 		}
 	}
 
-	if (m_pPlayer->m_flEjectBrass != 0 && m_pPlayer->m_flEjectBrass <= gpGlobals->time)
+	if (m_hPlayer->m_flEjectBrass != 0 && m_hPlayer->m_flEjectBrass <= gpGlobals->time)
 	{
-		m_pPlayer->m_flEjectBrass = 0;
+		m_hPlayer->m_flEjectBrass = 0;
 		EjectBrassLate();
 	}
 
-	if (!(m_pPlayer->pev->button & IN_ATTACK))
+	if (!(m_hPlayer->pev->button & IN_ATTACK))
 	{
 		m_flLastFireTime = 0;
 	}
 
-	if (m_pPlayer->HasShield())
+	if (m_hPlayer->HasShield())
 	{
-		if (m_fInReload && (m_pPlayer->pev->button & IN_ATTACK2))
+		if (m_fInReload && (m_hPlayer->pev->button & IN_ATTACK2))
 		{
 			SecondaryAttack();
-			m_pPlayer->pev->button &= ~IN_ATTACK2;
+			m_hPlayer->pev->button &= ~IN_ATTACK2;
 			m_fInReload = FALSE;
-			m_pPlayer->m_flNextAttack = UTIL_WeaponTimeBase();
+			m_hPlayer->m_flNextAttack = UTIL_WeaponTimeBase();
 		}
 	}
 
-	if (m_fInReload && m_pPlayer->m_flNextAttack <= UTIL_WeaponTimeBase())
+	if (m_fInReload && m_hPlayer->m_flNextAttack <= UTIL_WeaponTimeBase())
 	{
 		// complete the reload.
-		int j = Q_min(iMaxClip() - m_iClip, m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType]);
+		int j = Q_min(iMaxClip() - m_iClip, m_hPlayer->m_rgAmmo[m_iPrimaryAmmoType]);
 
 		// Add them to the clip
 		m_iClip += j;
@@ -954,46 +954,46 @@ void CBasePlayerWeapon::ItemPostFrame()
 		if (refill_bpammo_weapons.value < 3.0f)
 #endif
 		{
-			m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType] -= j;
+			m_hPlayer->m_rgAmmo[m_iPrimaryAmmoType] -= j;
 		}
 
-		m_pPlayer->TabulateAmmo();
+		m_hPlayer->TabulateAmmo();
 		m_fInReload = FALSE;
 	}
 
 	if ((usableButtons & IN_ATTACK2) && CanAttack(m_flNextSecondaryAttack, UTIL_WeaponTimeBase(), UseDecrement())
 #ifdef REGAMEDLL_FIXES
-		&& !m_pPlayer->m_bIsDefusing // In-line: I think it's fine to block secondary attack, when defusing. It's better then blocking speed resets in weapons.
+		&& !m_hPlayer->m_bIsDefusing // In-line: I think it's fine to block secondary attack, when defusing. It's better then blocking speed resets in weapons.
 #endif
     )
 	{
-		if (pszAmmo2() && !m_pPlayer->m_rgAmmo[SecondaryAmmoIndex()])
+		if (pszAmmo2() && !m_hPlayer->m_rgAmmo[SecondaryAmmoIndex()])
 		{
 			m_fFireOnEmpty = TRUE;
 		}
 
 		SecondaryAttack();
-		m_pPlayer->pev->button &= ~IN_ATTACK2;
+		m_hPlayer->pev->button &= ~IN_ATTACK2;
 	}
-	else if ((m_pPlayer->pev->button & IN_ATTACK) && CanAttack(m_flNextPrimaryAttack, UTIL_WeaponTimeBase(), UseDecrement()))
+	else if ((m_hPlayer->pev->button & IN_ATTACK) && CanAttack(m_flNextPrimaryAttack, UTIL_WeaponTimeBase(), UseDecrement()))
 	{
-		if ((m_iClip == 0 && pszAmmo1()) || (iMaxClip() == WEAPON_NOCLIP && !m_pPlayer->m_rgAmmo[PrimaryAmmoIndex()]))
+		if ((m_iClip == 0 && pszAmmo1()) || (iMaxClip() == WEAPON_NOCLIP && !m_hPlayer->m_rgAmmo[PrimaryAmmoIndex()]))
 		{
 			m_fFireOnEmpty = TRUE;
 		}
 
-		m_pPlayer->TabulateAmmo();
+		m_hPlayer->TabulateAmmo();
 
 		// Can't shoot during the freeze period
 		// Always allow firing in single player
 		if (
 #ifdef REGAMEDLL_API
-			m_pPlayer->CSPlayer()->m_bCanShootOverride ||
+			m_hPlayer->CSPlayer()->m_bCanShootOverride ||
 #endif
-			(m_pPlayer->m_bCanShoot && g_pGameRules->IsMultiplayer() && !g_pGameRules->IsFreezePeriod() && !m_pPlayer->m_bIsDefusing) || !g_pGameRules->IsMultiplayer())
+			(m_hPlayer->m_bCanShoot && g_pGameRules->IsMultiplayer() && !g_pGameRules->IsFreezePeriod() && !m_hPlayer->m_bIsDefusing) || !g_pGameRules->IsMultiplayer())
 		{
 			// don't fire underwater
-			if (m_pPlayer->pev->waterlevel == 3 && (iFlags() & ITEM_FLAG_NOFIREUNDERWATER))
+			if (m_hPlayer->pev->waterlevel == 3 && (iFlags() & ITEM_FLAG_NOFIREUNDERWATER))
 			{
 				PlayEmptySound();
 				m_flNextPrimaryAttack = GetNextAttackDelay(0.15);
@@ -1004,7 +1004,7 @@ void CBasePlayerWeapon::ItemPostFrame()
 			}
 		}
 	}
-	else if ((m_pPlayer->pev->button & IN_RELOAD) && iMaxClip() != WEAPON_NOCLIP && !m_fInReload && m_flNextPrimaryAttack < UTIL_WeaponTimeBase())
+	else if ((m_hPlayer->pev->button & IN_RELOAD) && iMaxClip() != WEAPON_NOCLIP && !m_fInReload && m_flNextPrimaryAttack < UTIL_WeaponTimeBase())
 	{
 		// reload when reload is pressed, or if no buttons are down and weapon is empty.
 		if (m_flFamasShoot == 0 && m_flGlock18Shoot == 0)
@@ -1062,7 +1062,7 @@ void CBasePlayerWeapon::ItemPostFrame()
 		{
 #if 0
 			// weapon isn't useable, switch.
-			if (!(iFlags() & ITEM_FLAG_NOAUTOSWITCHEMPTY) && g_pGameRules->GetNextBestWeapon(m_pPlayer, this))
+			if (!(iFlags() & ITEM_FLAG_NOAUTOSWITCHEMPTY) && g_pGameRules->GetNextBestWeapon(m_hPlayer, this))
 			{
 				m_flNextPrimaryAttack = UTIL_WeaponTimeBase() + 0.3f;
 				return;
@@ -1106,18 +1106,18 @@ void CBasePlayerWeapon::ItemPostFrame()
 
 void CBasePlayerItem::DestroyItem()
 {
-	if (m_pPlayer)
+	if (m_hPlayer)
 	{
 		// if attached to a player, remove.
-		if (m_pPlayer->RemovePlayerItem(this))
+		if (m_hPlayer->RemovePlayerItem(this))
 		{
 
 #ifdef REGAMEDLL_FIXES
-			m_pPlayer->pev->weapons &= ~(1 << m_iId);
+			m_hPlayer->pev->weapons &= ~(1 << m_iId);
 
 			// No more weapon
-			if ((m_pPlayer->pev->weapons & ~(1 << WEAPON_SUIT)) == 0) {
-				m_pPlayer->m_iHideHUD |= HIDEHUD_WEAPONS;
+			if ((m_hPlayer->pev->weapons & ~(1 << WEAPON_SUIT)) == 0) {
+				m_hPlayer->m_iHideHUD |= HIDEHUD_WEAPONS;
 			}
 #endif
 
@@ -1129,7 +1129,7 @@ void CBasePlayerItem::DestroyItem()
 
 int CBasePlayerItem::AddToPlayer(CBasePlayer *pPlayer)
 {
-	m_pPlayer = pPlayer;
+	m_hPlayer = m_pPlayer = pPlayer;
 
 	MESSAGE_BEGIN(MSG_ONE, gmsgWeapPickup, nullptr, pPlayer->pev);
 		WRITE_BYTE(m_iId);
@@ -1154,8 +1154,8 @@ void CBasePlayerItem::Kill()
 
 void CBasePlayerItem::Holster(int skiplocal)
 {
-	m_pPlayer->pev->viewmodel = 0;
-	m_pPlayer->pev->weaponmodel = 0;
+	m_hPlayer->pev->viewmodel = 0;
+	m_hPlayer->pev->weaponmodel = 0;
 }
 
 void CBasePlayerItem::AttachToPlayer(CBasePlayer *pPlayer)
@@ -1211,7 +1211,7 @@ int CBasePlayerWeapon::AddDuplicate(CBasePlayerItem *pOriginal)
 
 int CBasePlayerWeapon::AddToPlayer(CBasePlayer *pPlayer)
 {
-	m_pPlayer = pPlayer;
+	m_hPlayer = m_pPlayer = pPlayer;
 	pPlayer->pev->weapons |= (1 << m_iId);
 
 	if (!m_iPrimaryAmmoType)
@@ -1233,7 +1233,7 @@ int CBasePlayerWeapon::UpdateClientData(CBasePlayer *pPlayer)
 	bool bSend = false;
 	int state = 0;
 
-	if (pPlayer->m_pActiveItem == this)
+	if (pPlayer->m_hActiveItem == this)
 	{
 		if (pPlayer->m_fOnTarget)
 			state = WEAPON_IS_ONTARGET;
@@ -1244,9 +1244,9 @@ int CBasePlayerWeapon::UpdateClientData(CBasePlayer *pPlayer)
 	if (!pPlayer->m_fWeapon)
 		bSend = true;
 
-	if (this == pPlayer->m_pActiveItem || this == pPlayer->m_pClientActiveItem)
+	if (this == pPlayer->m_hActiveItem || this == pPlayer->m_pClientActiveItem)
 	{
-		if (pPlayer->m_pActiveItem != pPlayer->m_pClientActiveItem)
+		if (pPlayer->m_hActiveItem != pPlayer->m_pClientActiveItem)
 			bSend = true;
 	}
 
@@ -1266,9 +1266,9 @@ int CBasePlayerWeapon::UpdateClientData(CBasePlayer *pPlayer)
 		pPlayer->m_fWeapon = TRUE;
 	}
 
-	if (m_pNext)
+	if (m_hNext)
 	{
-		m_pNext->UpdateClientData(pPlayer);
+		m_hNext->UpdateClientData(pPlayer);
 	}
 
 	return 1;
@@ -1276,14 +1276,14 @@ int CBasePlayerWeapon::UpdateClientData(CBasePlayer *pPlayer)
 
 void CBasePlayerWeapon::SendWeaponAnim(int iAnim, int skiplocal)
 {
-	m_pPlayer->pev->weaponanim = iAnim;
+	m_hPlayer->pev->weaponanim = iAnim;
 
 #ifdef CLIENT_WEAPONS
-	if (skiplocal && ENGINE_CANSKIP(m_pPlayer->edict()))
+	if (skiplocal && ENGINE_CANSKIP(m_hPlayer->edict()))
 		return;
 #endif
 
-	MESSAGE_BEGIN(MSG_ONE, SVC_WEAPONANIM, nullptr, m_pPlayer->pev);
+	MESSAGE_BEGIN(MSG_ONE, SVC_WEAPONANIM, nullptr, m_hPlayer->pev);
 		WRITE_BYTE(iAnim);		// sequence number
 		WRITE_BYTE(pev->body);	// weaponmodel bodygroup.
 	MESSAGE_END();
@@ -1296,7 +1296,7 @@ BOOL CBasePlayerWeapon::AddPrimaryAmmo(int iCount, char *szName, int iMaxClip, i
 	if (iMaxClip < 1)
 	{
 		m_iClip = WEAPON_NOCLIP;
-		iIdAmmo = m_pPlayer->GiveAmmo(iCount, szName, iMaxCarry);
+		iIdAmmo = m_hPlayer->GiveAmmo(iCount, szName, iMaxCarry);
 	}
 	else if (m_iClip == 0)
 	{
@@ -1304,17 +1304,17 @@ BOOL CBasePlayerWeapon::AddPrimaryAmmo(int iCount, char *szName, int iMaxClip, i
 		i = Q_min(m_iClip + iCount, iMaxClip);
 		m_iClip += i;
 
-		iIdAmmo = m_pPlayer->GiveAmmo(iCount - i, szName, iMaxCarry);
+		iIdAmmo = m_hPlayer->GiveAmmo(iCount - i, szName, iMaxCarry);
 	}
 	else
 	{
-		iIdAmmo = m_pPlayer->GiveAmmo(iCount, szName, iMaxCarry);
+		iIdAmmo = m_hPlayer->GiveAmmo(iCount, szName, iMaxCarry);
 	}
 
 	if (iIdAmmo > 0)
 	{
 		m_iPrimaryAmmoType = iIdAmmo;
-		if (m_pPlayer->HasPlayerItem(this))
+		if (m_hPlayer->HasPlayerItem(this))
 		{
 			// play the "got ammo" sound only if we gave some ammo to a player that already had this gun.
 			// if the player is just getting this gun for the first time, DefaultTouch will play the "picked up gun" sound for us.
@@ -1327,7 +1327,7 @@ BOOL CBasePlayerWeapon::AddPrimaryAmmo(int iCount, char *szName, int iMaxClip, i
 
 BOOL CBasePlayerWeapon::AddSecondaryAmmo(int iCount, char *szName, int iMax)
 {
-	int iIdAmmo = m_pPlayer->GiveAmmo(iCount, szName, iMax);
+	int iIdAmmo = m_hPlayer->GiveAmmo(iCount, szName, iMax);
 
 	if (iIdAmmo > 0)
 	{
@@ -1346,7 +1346,7 @@ BOOL CBasePlayerWeapon::IsUseable()
 {
 	if (m_iClip <= 0)
 	{
-		if (m_pPlayer->m_rgAmmo[PrimaryAmmoIndex()] <= 0 && iMaxAmmo1() != -1)
+		if (m_hPlayer->m_rgAmmo[PrimaryAmmoIndex()] <= 0 && iMaxAmmo1() != -1)
 		{
 			// clip is empty (or nonexistant) and the player has no more ammo of this type.
 			return FALSE;
@@ -1370,27 +1370,27 @@ BOOL EXT_FUNC CBasePlayerWeapon::__API_HOOK(DefaultDeploy)(char *szViewModel, ch
 	if (!CanDeploy())
 		return FALSE;
 
-	m_pPlayer->TabulateAmmo();
+	m_hPlayer->TabulateAmmo();
 #ifdef REGAMEDLL_API
-	m_pPlayer->pev->viewmodel = ALLOC_STRING(szViewModel);
-	m_pPlayer->pev->weaponmodel = ALLOC_STRING(szWeaponModel);
+	m_hPlayer->pev->viewmodel = ALLOC_STRING(szViewModel);
+	m_hPlayer->pev->weaponmodel = ALLOC_STRING(szWeaponModel);
 #else
-	m_pPlayer->pev->viewmodel = MAKE_STRING(szViewModel);
-	m_pPlayer->pev->weaponmodel = MAKE_STRING(szWeaponModel);
+	m_hPlayer->pev->viewmodel = MAKE_STRING(szViewModel);
+	m_hPlayer->pev->weaponmodel = MAKE_STRING(szWeaponModel);
 #endif
-	model_name = m_pPlayer->pev->viewmodel;
-	Q_strcpy(m_pPlayer->m_szAnimExtention, szAnimExt);
+	model_name = m_hPlayer->pev->viewmodel;
+	Q_strcpy(m_hPlayer->m_szAnimExtention, szAnimExt);
 	SendWeaponAnim(iAnim, skiplocal);
 
-	m_pPlayer->m_flNextAttack = 0.75f;
+	m_hPlayer->m_flNextAttack = 0.75f;
 	m_flTimeWeaponIdle = 1.5f;
 	m_flLastFireTime = 0.0f;
 	m_flDecreaseShotsFired = gpGlobals->time;
 
-	m_pPlayer->m_iFOV = DEFAULT_FOV;
-	m_pPlayer->pev->fov = DEFAULT_FOV;
-	m_pPlayer->m_iLastZoom = DEFAULT_FOV;
-	m_pPlayer->m_bResumeZoom = false;
+	m_hPlayer->m_iFOV = DEFAULT_FOV;
+	m_hPlayer->pev->fov = DEFAULT_FOV;
+	m_hPlayer->m_iLastZoom = DEFAULT_FOV;
+	m_hPlayer->m_bResumeZoom = false;
 
 	return TRUE;
 }
@@ -1403,10 +1403,10 @@ void CBasePlayerWeapon::ReloadSound()
 		if (pPlayer->IsDormant())
 			break;
 
-		if (pPlayer == m_pPlayer)
+		if (pPlayer == m_hPlayer)
 			continue;
 
-		float distance = (m_pPlayer->pev->origin - pPlayer->pev->origin).Length();
+		float distance = (m_hPlayer->pev->origin - pPlayer->pev->origin).Length();
 		if (distance <= MAX_DIST_RELOAD_SOUND)
 		{
 			MESSAGE_BEGIN(MSG_ONE, gmsgReloadSound, nullptr, pPlayer->pev);
@@ -1424,16 +1424,16 @@ LINK_HOOK_CLASS_CHAIN(int, CBasePlayerWeapon, DefaultReload, (int iClipSize, int
 
 int EXT_FUNC CBasePlayerWeapon::__API_HOOK(DefaultReload)(int iClipSize, int iAnim, float fDelay)
 {
-	if (m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType] <= 0)
+	if (m_hPlayer->m_rgAmmo[m_iPrimaryAmmoType] <= 0)
 		return FALSE;
 
-	int j = Q_min(iClipSize - m_iClip, m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType]);
+	int j = Q_min(iClipSize - m_iClip, m_hPlayer->m_rgAmmo[m_iPrimaryAmmoType]);
 	if (!j)
 	{
 		return FALSE;
 	}
 
-	m_pPlayer->m_flNextAttack = fDelay;
+	m_hPlayer->m_flNextAttack = fDelay;
 
 	ReloadSound();
 	SendWeaponAnim(iAnim, UseDecrement() ? 1 : 0);
@@ -1448,7 +1448,7 @@ LINK_HOOK_CLASS_CHAIN(bool, CBasePlayerWeapon, DefaultShotgunReload, (int iAnim,
 
 bool EXT_FUNC CBasePlayerWeapon::__API_HOOK(DefaultShotgunReload)(int iAnim, int iStartAnim, float fDelay, float fStartDelay, const char *pszReloadSound1, const char *pszReloadSound2)
 {
-	if (m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType] <= 0 || m_iClip == iMaxClip())
+	if (m_hPlayer->m_rgAmmo[m_iPrimaryAmmoType] <= 0 || m_iClip == iMaxClip())
 		return false;
 
 	// don't reload until recoil is done
@@ -1458,11 +1458,11 @@ bool EXT_FUNC CBasePlayerWeapon::__API_HOOK(DefaultShotgunReload)(int iAnim, int
 	// check to see if we're ready to reload
 	if (m_fInSpecialReload == 0)
 	{
-		m_pPlayer->SetAnimation(PLAYER_RELOAD);
+		m_hPlayer->SetAnimation(PLAYER_RELOAD);
 		SendWeaponAnim(iStartAnim, UseDecrement() != FALSE);
 
 		m_fInSpecialReload = 1;
-		m_flNextSecondaryAttack = m_flTimeWeaponIdle = m_pPlayer->m_flNextAttack = UTIL_WeaponTimeBase() + fStartDelay;
+		m_flNextSecondaryAttack = m_flTimeWeaponIdle = m_hPlayer->m_flNextAttack = UTIL_WeaponTimeBase() + fStartDelay;
 		m_flNextPrimaryAttack = GetNextAttackDelay(fStartDelay);
 	}
 	else if (m_fInSpecialReload == 1)
@@ -1480,7 +1480,7 @@ bool EXT_FUNC CBasePlayerWeapon::__API_HOOK(DefaultShotgunReload)(int iAnim, int
 
 		if (pszReloadSound && pszReloadSound[0] != '\0')
 		{
-			EMIT_SOUND_DYN(m_pPlayer->edict(), CHAN_ITEM, pszReloadSound, VOL_NORM, ATTN_NORM, 0, 85 + RANDOM_LONG(0, 31));
+			EMIT_SOUND_DYN(m_hPlayer->edict(), CHAN_ITEM, pszReloadSound, VOL_NORM, ATTN_NORM, 0, 85 + RANDOM_LONG(0, 31));
 		}
 
 		SendWeaponAnim(iAnim, UseDecrement());
@@ -1498,8 +1498,8 @@ bool EXT_FUNC CBasePlayerWeapon::__API_HOOK(DefaultShotgunReload)(int iAnim, int
 		if (refill_bpammo_weapons.value < 3.0f)
 #endif
 		{
-			m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType]--;
-			m_pPlayer->ammo_buckshot--;
+			m_hPlayer->m_rgAmmo[m_iPrimaryAmmoType]--;
+			m_hPlayer->ammo_buckshot--;
 		}
 
 		m_fInSpecialReload = 1;
@@ -1520,10 +1520,10 @@ BOOL CBasePlayerWeapon::PlayEmptySound()
 		case WEAPON_DEAGLE:
 		case WEAPON_ELITE:
 		case WEAPON_FIVESEVEN:
-			EMIT_SOUND(ENT(m_pPlayer->pev), CHAN_WEAPON, "weapons/dryfire_pistol.wav", 0.8, ATTN_NORM);
+			EMIT_SOUND(ENT(m_hPlayer->pev), CHAN_WEAPON, "weapons/dryfire_pistol.wav", 0.8, ATTN_NORM);
 			break;
 		default:
-			EMIT_SOUND(ENT(m_pPlayer->pev), CHAN_WEAPON, "weapons/dryfire_rifle.wav", 0.8, ATTN_NORM);
+			EMIT_SOUND(ENT(m_hPlayer->pev), CHAN_WEAPON, "weapons/dryfire_rifle.wav", 0.8, ATTN_NORM);
 			break;
 		}
 	}
@@ -1550,8 +1550,8 @@ void CBasePlayerWeapon::Holster(int skiplocal)
 {
 	// cancel any reload in progress.
 	m_fInReload = FALSE;
-	m_pPlayer->pev->viewmodel = 0;
-	m_pPlayer->pev->weaponmodel = 0;
+	m_hPlayer->pev->viewmodel = 0;
+	m_hPlayer->pev->weaponmodel = 0;
 }
 
 // called by the new item with the existing item as parameter
@@ -1593,17 +1593,17 @@ int CBasePlayerWeapon::ExtractClipAmmo(CBasePlayerWeapon *pWeapon)
 		iAmmo = m_iClip;
 	}
 
-	return pWeapon->m_pPlayer->GiveAmmo(iAmmo, pszAmmo1(), iMaxAmmo1());
+	return pWeapon->m_hPlayer->GiveAmmo(iAmmo, pszAmmo1(), iMaxAmmo1());
 }
 
 // RetireWeapon - no more ammo for this gun, put it away.
 void CBasePlayerWeapon::RetireWeapon()
 {
 	// first, no viewmodel at all.
-	m_pPlayer->pev->viewmodel = iStringNull;
-	m_pPlayer->pev->weaponmodel = iStringNull;
+	m_hPlayer->pev->viewmodel = iStringNull;
+	m_hPlayer->pev->weaponmodel = iStringNull;
 
-	g_pGameRules->GetNextBestWeapon(m_pPlayer, this);
+	g_pGameRules->GetNextBestWeapon(m_hPlayer, this);
 }
 
 // GetNextAttackDelay - An accurate way of calcualting the next attack time.
@@ -1657,14 +1657,14 @@ void CBasePlayerWeapon::InstantReload(bool bCanRefillBPAmmo)
 	//if (m_fInReload)
 	//	return;
 
-	if (m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType] <= 0)
+	if (m_hPlayer->m_rgAmmo[m_iPrimaryAmmoType] <= 0)
 		return;
 
 	m_fInReload = FALSE;
-	m_pPlayer->m_flNextAttack = 0;
+	m_hPlayer->m_flNextAttack = 0;
 
 	// complete the reload.
-	int j = Q_min(iMaxClip() - m_iClip, m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType]);
+	int j = Q_min(iMaxClip() - m_iClip, m_hPlayer->m_rgAmmo[m_iPrimaryAmmoType]);
 	if (j == 0)
 		return;
 
@@ -1672,10 +1672,10 @@ void CBasePlayerWeapon::InstantReload(bool bCanRefillBPAmmo)
 	m_iClip += j;
 
 	if (!bCanRefillBPAmmo) {
-		m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType] -= j;
+		m_hPlayer->m_rgAmmo[m_iPrimaryAmmoType] -= j;
 	}
 
-	m_pPlayer->TabulateAmmo();
+	m_hPlayer->TabulateAmmo();
 }
 
 TYPEDESCRIPTION CWeaponBox::m_SaveData[] =
@@ -1770,7 +1770,7 @@ void CWeaponBox::Kill()
 		{
 			pWeapon->SetThink(&CBaseEntity::SUB_Remove);
 			pWeapon->pev->nextthink = gpGlobals->time + 0.1f;
-			pWeapon = pWeapon->m_pNext;
+			pWeapon = pWeapon->m_hNext;
 		}
 	}
 
@@ -1906,7 +1906,7 @@ void CWeaponBox::Touch(CBaseEntity *pOther)
 				}
 			}
 
-			if (i >= PRIMARY_WEAPON_SLOT && i <= PISTOL_SLOT && pPlayer->m_rgpPlayerItems[i])
+			if (i >= PRIMARY_WEAPON_SLOT && i <= PISTOL_SLOT && pPlayer->m_rghPlayerItems[i])
 			{
 				// ...
 			}
@@ -1921,7 +1921,7 @@ void CWeaponBox::Touch(CBaseEntity *pOther)
 					auto info = GetWeaponInfo(pGrenade->m_iId);
 					if (info && playerGrenades < info->maxRounds)
 					{
-						auto pNext = m_rgpPlayerItems[i]->m_pNext;
+						auto pNext = m_rgpPlayerItems[i]->m_hNext.GetPtr();
 						if (pPlayer->AddPlayerItem(pItem))
 						{
 							pItem->AttachToPlayer(pPlayer);
@@ -1965,7 +1965,7 @@ void CWeaponBox::Touch(CBaseEntity *pOther)
 						pPlayer->GiveNamedItem(grenadeName);
 
 						// unlink this weapon from the box
-						pItem = m_rgpPlayerItems[i]->m_pNext;
+						pItem = m_rgpPlayerItems[i]->m_hNext.GetPtr();
 						m_rgpPlayerItems[i] = pItem;
 						continue;
 					}
@@ -1979,7 +1979,7 @@ void CWeaponBox::Touch(CBaseEntity *pOther)
 			}
 			else
 			{
-				auto pNext = m_rgpPlayerItems[i]->m_pNext;
+				auto pNext = m_rgpPlayerItems[i]->m_hNext.GetPtr();
 				if (pPlayer->AddPlayerItem(pItem))
 				{
 					pItem->AttachToPlayer(pPlayer);
@@ -1992,7 +1992,7 @@ void CWeaponBox::Touch(CBaseEntity *pOther)
 			}
 
 			bRemove = false;
-			pItem = m_rgpPlayerItems[i]->m_pNext;
+			pItem = m_rgpPlayerItems[i]->m_hNext.GetPtr();
 		}
 	}
 
@@ -2035,14 +2035,14 @@ BOOL CWeaponBox::PackWeapon(CBasePlayerItem *pWeapon)
 		return FALSE;
 	}
 
-	if (pWeapon->m_pPlayer)
+	if (pWeapon->m_hPlayer)
 	{
-		if (pWeapon->m_pPlayer->m_pActiveItem == pWeapon)
+		if (pWeapon->m_hPlayer->m_hActiveItem == pWeapon)
 		{
 			pWeapon->Holster();
 		}
 
-		if (!pWeapon->m_pPlayer->RemovePlayerItem(pWeapon))
+		if (!pWeapon->m_hPlayer->RemovePlayerItem(pWeapon))
 		{
 			// failed to unhook the weapon from the player!
 			return FALSE;
@@ -2053,14 +2053,14 @@ BOOL CWeaponBox::PackWeapon(CBasePlayerItem *pWeapon)
 	if (m_rgpPlayerItems[iWeaponSlot])
 	{
 		// there's already one weapon in this slot, so link this into the slot's column
-		pWeapon->m_pNext = m_rgpPlayerItems[iWeaponSlot];
+		pWeapon->m_hNext = pWeapon->m_pNext = m_rgpPlayerItems[iWeaponSlot];
 		m_rgpPlayerItems[iWeaponSlot] = pWeapon;
 	}
 	else
 	{
 		// first weapon we have for this slot
 		m_rgpPlayerItems[iWeaponSlot] = pWeapon;
-		pWeapon->m_pNext = nullptr;
+		pWeapon->m_hNext = pWeapon->m_pNext = nullptr;
 	}
 
 	// never respawn
@@ -2073,7 +2073,7 @@ BOOL CWeaponBox::PackWeapon(CBasePlayerItem *pWeapon)
 	pWeapon->pev->owner = ENT(pev);
 	pWeapon->SetThink(nullptr);
 	pWeapon->SetTouch(nullptr);
-	pWeapon->m_pPlayer = nullptr;
+	pWeapon->m_hPlayer = pWeapon->m_pPlayer = nullptr;
 
 	return TRUE;
 }
@@ -2143,7 +2143,7 @@ BOOL CWeaponBox::HasWeapon(CBasePlayerItem *pCheckItem)
 			return TRUE;
 		}
 
-		pItem = pItem->m_pNext;
+		pItem = pItem->m_hNext.GetPtr();
 	}
 
 	return FALSE;
@@ -2436,7 +2436,7 @@ void CArmoury::ArmouryTouch(CBaseEntity *pOther)
 	// secondary weapons (pistols)
 	else if (m_iCount > 0 && m_iItem >= ARMOURY_GLOCK18)
 	{
-		if (pToucher->m_rgpPlayerItems[PISTOL_SLOT])
+		if (pToucher->m_rghPlayerItems[PISTOL_SLOT])
 			return;
 
 		if (pToucher->HasShield() && m_iItem == ARMOURY_ELITE)
@@ -2515,7 +2515,7 @@ void CArmoury::ArmouryTouch(CBaseEntity *pOther)
 #ifdef REGAMEDLL_ADD
 		case ARMOURY_SHIELD:
 		{
-			if (pToucher->m_bHasPrimary || (pToucher->m_rgpPlayerItems[PISTOL_SLOT] && pToucher->GetItemById(WEAPON_ELITE)))
+			if (pToucher->m_bHasPrimary || (pToucher->m_rghPlayerItems[PISTOL_SLOT] && pToucher->GetItemById(WEAPON_ELITE)))
 				return;
 
 			pToucher->GiveNamedItemEx("weapon_shield");

--- a/regamedll/dlls/weapons.h
+++ b/regamedll/dlls/weapons.h
@@ -324,9 +324,19 @@ public:
 	static ItemInfo m_ItemInfoArray[MAX_WEAPONS];
 	static AmmoInfo m_AmmoInfoArray[MAX_AMMO_SLOTS];
 
+	////
+	// DEPRECATED: Use safe pointers instead it
+	////
 	CBasePlayer *m_pPlayer;
 	CBasePlayerItem *m_pNext;
+	////
+	// DEPRECATED: Use safe pointers instead it
+	////
+
 	int m_iId;							// WEAPON_???
+
+	EntityHandle<CBasePlayer> m_hPlayer;
+	EntityHandle<CBasePlayerItem> m_hNext;
 };
 
 #ifdef REGAMEDLL_API

--- a/regamedll/dlls/wpn_shared/wpn_ak47.cpp
+++ b/regamedll/dlls/wpn_shared/wpn_ak47.cpp
@@ -72,11 +72,11 @@ void CAK47::SecondaryAttack()
 
 void CAK47::PrimaryAttack()
 {
-	if (!(m_pPlayer->pev->flags & FL_ONGROUND))
+	if (!(m_hPlayer->pev->flags & FL_ONGROUND))
 	{
 		AK47Fire(0.04 + (0.4 * m_flAccuracy), 0.0955, FALSE);
 	}
-	else if (m_pPlayer->pev->velocity.Length2D() > 140)
+	else if (m_hPlayer->pev->velocity.Length2D() > 140)
 	{
 		AK47Fire(0.04 + (0.07 * m_flAccuracy), 0.0955, FALSE);
 	}
@@ -109,19 +109,19 @@ void CAK47::AK47Fire(float flSpread, float flCycleTime, BOOL fUseAutoAim)
 
 		if (TheBots)
 		{
-			TheBots->OnEvent(EVENT_WEAPON_FIRED_ON_EMPTY, m_pPlayer);
+			TheBots->OnEvent(EVENT_WEAPON_FIRED_ON_EMPTY, m_hPlayer);
 		}
 
 		return;
 	}
 
 	m_iClip--;
-	m_pPlayer->pev->effects |= EF_MUZZLEFLASH;
-	m_pPlayer->SetAnimation(PLAYER_ATTACK1);
+	m_hPlayer->pev->effects |= EF_MUZZLEFLASH;
+	m_hPlayer->SetAnimation(PLAYER_ATTACK1);
 
-	UTIL_MakeVectors(m_pPlayer->pev->v_angle + m_pPlayer->pev->punchangle);
+	UTIL_MakeVectors(m_hPlayer->pev->v_angle + m_hPlayer->pev->punchangle);
 
-	vecSrc = m_pPlayer->GetGunPosition();
+	vecSrc = m_hPlayer->GetGunPosition();
 	vecAiming = gpGlobals->v_forward;
 
 #ifdef REGAMEDLL_API
@@ -129,8 +129,8 @@ void CAK47::AK47Fire(float flSpread, float flCycleTime, BOOL fUseAutoAim)
 #else
 	float flBaseDamage = AK47_DAMAGE;
 #endif
-	vecDir = m_pPlayer->FireBullets3(vecSrc, vecAiming, flSpread, 8192, 2, BULLET_PLAYER_762MM,
-		flBaseDamage, AK47_RANGE_MODIFER, m_pPlayer->pev, false, m_pPlayer->random_seed);
+	vecDir = m_hPlayer->FireBullets3(vecSrc, vecAiming, flSpread, 8192, 2, BULLET_PLAYER_762MM,
+		flBaseDamage, AK47_RANGE_MODIFER, m_hPlayer->pev, false, m_hPlayer->random_seed);
 
 #ifdef CLIENT_WEAPONS
 	flag = FEV_NOTHOST;
@@ -138,30 +138,30 @@ void CAK47::AK47Fire(float flSpread, float flCycleTime, BOOL fUseAutoAim)
 	flag = 0;
 #endif
 
-	PLAYBACK_EVENT_FULL(flag, m_pPlayer->edict(), m_usFireAK47, 0, (float *)&g_vecZero, (float *)&g_vecZero, vecDir.x, vecDir.y,
-		int(m_pPlayer->pev->punchangle.x * 100), int(m_pPlayer->pev->punchangle.y * 100), FALSE, FALSE);
+	PLAYBACK_EVENT_FULL(flag, m_hPlayer->edict(), m_usFireAK47, 0, (float *)&g_vecZero, (float *)&g_vecZero, vecDir.x, vecDir.y,
+		int(m_hPlayer->pev->punchangle.x * 100), int(m_hPlayer->pev->punchangle.y * 100), FALSE, FALSE);
 
-	m_pPlayer->m_iWeaponVolume = NORMAL_GUN_VOLUME;
-	m_pPlayer->m_iWeaponFlash = BRIGHT_GUN_FLASH;
+	m_hPlayer->m_iWeaponVolume = NORMAL_GUN_VOLUME;
+	m_hPlayer->m_iWeaponFlash = BRIGHT_GUN_FLASH;
 
 	m_flNextPrimaryAttack = m_flNextSecondaryAttack = GetNextAttackDelay(flCycleTime);
 
-	if (!m_iClip && m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType] <= 0)
+	if (!m_iClip && m_hPlayer->m_rgAmmo[m_iPrimaryAmmoType] <= 0)
 	{
-		m_pPlayer->SetSuitUpdate("!HEV_AMO0", SUIT_SENTENCE, SUIT_REPEAT_OK);
+		m_hPlayer->SetSuitUpdate("!HEV_AMO0", SUIT_SENTENCE, SUIT_REPEAT_OK);
 	}
 
 	m_flTimeWeaponIdle = UTIL_WeaponTimeBase() + 1.9f;
 
-	if (m_pPlayer->pev->velocity.Length2D() > 0)
+	if (m_hPlayer->pev->velocity.Length2D() > 0)
 	{
 		KickBack(1.5, 0.45, 0.225, 0.05, 6.5, 2.5, 7);
 	}
-	else if (!(m_pPlayer->pev->flags & FL_ONGROUND))
+	else if (!(m_hPlayer->pev->flags & FL_ONGROUND))
 	{
 		KickBack(2.0, 1.0, 0.5, 0.35, 9.0, 6.0, 5);
 	}
-	else if (m_pPlayer->pev->flags & FL_DUCKING)
+	else if (m_hPlayer->pev->flags & FL_DUCKING)
 	{
 		KickBack(0.9, 0.35, 0.15, 0.025, 5.5, 1.5, 9);
 	}
@@ -175,13 +175,13 @@ void CAK47::Reload()
 {
 #ifdef REGAMEDLL_FIXES
 	// to prevent reload if not enough ammo
-	if (m_pPlayer->ammo_762nato <= 0)
+	if (m_hPlayer->ammo_762nato <= 0)
 		return;
 #endif
 
 	if (DefaultReload(iMaxClip(), AK47_RELOAD, AK47_RELOAD_TIME))
 	{
-		m_pPlayer->SetAnimation(PLAYER_RELOAD);
+		m_hPlayer->SetAnimation(PLAYER_RELOAD);
 
 		m_flAccuracy = 0.2f;
 		m_iShotsFired = 0;
@@ -192,7 +192,7 @@ void CAK47::Reload()
 void CAK47::WeaponIdle()
 {
 	ResetEmptySound();
-	m_pPlayer->GetAutoaimVector(AUTOAIM_10DEGREES);
+	m_hPlayer->GetAutoaimVector(AUTOAIM_10DEGREES);
 
 	if (m_flTimeWeaponIdle <= UTIL_WeaponTimeBase())
 	{

--- a/regamedll/dlls/wpn_shared/wpn_aug.cpp
+++ b/regamedll/dlls/wpn_shared/wpn_aug.cpp
@@ -68,25 +68,25 @@ BOOL CAUG::Deploy()
 
 void CAUG::SecondaryAttack()
 {
-	if (m_pPlayer->m_iFOV == DEFAULT_FOV)
-		m_pPlayer->pev->fov = m_pPlayer->m_iFOV = 55;
+	if (m_hPlayer->m_iFOV == DEFAULT_FOV)
+		m_hPlayer->pev->fov = m_hPlayer->m_iFOV = 55;
 	else
-		m_pPlayer->pev->fov = m_pPlayer->m_iFOV = 90;
+		m_hPlayer->pev->fov = m_hPlayer->m_iFOV = 90;
 
 	m_flNextSecondaryAttack = UTIL_WeaponTimeBase() + 0.3f;
 }
 
 void CAUG::PrimaryAttack()
 {
-	if (!(m_pPlayer->pev->flags & FL_ONGROUND))
+	if (!(m_hPlayer->pev->flags & FL_ONGROUND))
 	{
 		AUGFire(0.035 + (0.4 * m_flAccuracy), 0.0825, FALSE);
 	}
-	else if (m_pPlayer->pev->velocity.Length2D() > 140)
+	else if (m_hPlayer->pev->velocity.Length2D() > 140)
 	{
 		AUGFire(0.035 + (0.07 * m_flAccuracy), 0.0825, FALSE);
 	}
-	else if (m_pPlayer->pev->fov == DEFAULT_FOV)
+	else if (m_hPlayer->pev->fov == DEFAULT_FOV)
 	{
 		AUGFire(0.02 * m_flAccuracy, 0.0825, FALSE);
 	}
@@ -119,22 +119,22 @@ void CAUG::AUGFire(float flSpread, float flCycleTime, BOOL fUseAutoAim)
 
 		if (TheBots)
 		{
-			TheBots->OnEvent(EVENT_WEAPON_FIRED_ON_EMPTY, m_pPlayer);
+			TheBots->OnEvent(EVENT_WEAPON_FIRED_ON_EMPTY, m_hPlayer);
 		}
 
 		return;
 	}
 
 	m_iClip--;
-	m_pPlayer->pev->effects |= EF_MUZZLEFLASH;
-	m_pPlayer->SetAnimation(PLAYER_ATTACK1);
+	m_hPlayer->pev->effects |= EF_MUZZLEFLASH;
+	m_hPlayer->SetAnimation(PLAYER_ATTACK1);
 
-	m_pPlayer->m_iWeaponVolume = NORMAL_GUN_VOLUME;
-	m_pPlayer->m_iWeaponFlash = BRIGHT_GUN_FLASH;
+	m_hPlayer->m_iWeaponVolume = NORMAL_GUN_VOLUME;
+	m_hPlayer->m_iWeaponFlash = BRIGHT_GUN_FLASH;
 
-	UTIL_MakeVectors(m_pPlayer->pev->v_angle + m_pPlayer->pev->punchangle);
+	UTIL_MakeVectors(m_hPlayer->pev->v_angle + m_hPlayer->pev->punchangle);
 
-	vecSrc = m_pPlayer->GetGunPosition();
+	vecSrc = m_hPlayer->GetGunPosition();
 	vecAiming = gpGlobals->v_forward;
 
 #ifdef REGAMEDLL_API
@@ -142,8 +142,8 @@ void CAUG::AUGFire(float flSpread, float flCycleTime, BOOL fUseAutoAim)
 #else
 	float flBaseDamage = AUG_DAMAGE;
 #endif
-	vecDir = m_pPlayer->FireBullets3(vecSrc, vecAiming, flSpread, 8192, 2, BULLET_PLAYER_556MM,
-		flBaseDamage, AUG_RANGE_MODIFER, m_pPlayer->pev, false, m_pPlayer->random_seed);
+	vecDir = m_hPlayer->FireBullets3(vecSrc, vecAiming, flSpread, 8192, 2, BULLET_PLAYER_556MM,
+		flBaseDamage, AUG_RANGE_MODIFER, m_hPlayer->pev, false, m_hPlayer->random_seed);
 
 #ifdef CLIENT_WEAPONS
 	flag = FEV_NOTHOST;
@@ -151,27 +151,27 @@ void CAUG::AUGFire(float flSpread, float flCycleTime, BOOL fUseAutoAim)
 	flag = 0;
 #endif
 
-	PLAYBACK_EVENT_FULL(flag, m_pPlayer->edict(), m_usFireAug, 0, (float *)&g_vecZero, (float *)&g_vecZero, vecDir.x, vecDir.y,
-		int(m_pPlayer->pev->punchangle.x * 100), int(m_pPlayer->pev->punchangle.y * 100), FALSE, FALSE);
+	PLAYBACK_EVENT_FULL(flag, m_hPlayer->edict(), m_usFireAug, 0, (float *)&g_vecZero, (float *)&g_vecZero, vecDir.x, vecDir.y,
+		int(m_hPlayer->pev->punchangle.x * 100), int(m_hPlayer->pev->punchangle.y * 100), FALSE, FALSE);
 
 	m_flNextPrimaryAttack = m_flNextSecondaryAttack = GetNextAttackDelay(flCycleTime);
 
-	if (!m_iClip && m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType] <= 0)
+	if (!m_iClip && m_hPlayer->m_rgAmmo[m_iPrimaryAmmoType] <= 0)
 	{
-		m_pPlayer->SetSuitUpdate("!HEV_AMO0", SUIT_SENTENCE, SUIT_REPEAT_OK);
+		m_hPlayer->SetSuitUpdate("!HEV_AMO0", SUIT_SENTENCE, SUIT_REPEAT_OK);
 	}
 
 	m_flTimeWeaponIdle = UTIL_WeaponTimeBase() + 1.9f;
 
-	if (m_pPlayer->pev->velocity.Length2D() > 0)
+	if (m_hPlayer->pev->velocity.Length2D() > 0)
 	{
 		KickBack(1.0, 0.45, 0.275, 0.05, 4.0, 2.5, 7);
 	}
-	else if (!(m_pPlayer->pev->flags & FL_ONGROUND))
+	else if (!(m_hPlayer->pev->flags & FL_ONGROUND))
 	{
 		KickBack(1.25, 0.45, 0.22, 0.18, 5.5, 4.0, 5);
 	}
-	else if (m_pPlayer->pev->flags & FL_DUCKING)
+	else if (m_hPlayer->pev->flags & FL_DUCKING)
 	{
 		KickBack(0.575, 0.325, 0.2, 0.011, 3.25, 2.0, 8);
 	}
@@ -183,14 +183,14 @@ void CAUG::AUGFire(float flSpread, float flCycleTime, BOOL fUseAutoAim)
 
 void CAUG::Reload()
 {
-	if (m_pPlayer->ammo_556nato <= 0)
+	if (m_hPlayer->ammo_556nato <= 0)
 		return;
 
 	if (DefaultReload(iMaxClip(), AUG_RELOAD, AUG_RELOAD_TIME))
 	{
-		m_pPlayer->SetAnimation(PLAYER_RELOAD);
+		m_hPlayer->SetAnimation(PLAYER_RELOAD);
 
-		if (m_pPlayer->m_iFOV != DEFAULT_FOV)
+		if (m_hPlayer->m_iFOV != DEFAULT_FOV)
 		{
 			SecondaryAttack();
 		}
@@ -204,7 +204,7 @@ void CAUG::Reload()
 void CAUG::WeaponIdle()
 {
 	ResetEmptySound();
-	m_pPlayer->GetAutoaimVector(AUTOAIM_10DEGREES);
+	m_hPlayer->GetAutoaimVector(AUTOAIM_10DEGREES);
 
 	if (m_flTimeWeaponIdle > UTIL_WeaponTimeBase())
 	{

--- a/regamedll/dlls/wpn_shared/wpn_awp.cpp
+++ b/regamedll/dlls/wpn_shared/wpn_awp.cpp
@@ -62,8 +62,8 @@ BOOL CAWP::Deploy()
 {
 	if (DefaultDeploy("models/v_awp.mdl", "models/p_awp.mdl", AWP_DRAW, "rifle", UseDecrement() != FALSE))
 	{
-		m_pPlayer->m_flNextAttack = GetNextAttackDelay(1.45);
-		m_flNextPrimaryAttack = m_pPlayer->m_flNextAttack;
+		m_hPlayer->m_flNextAttack = GetNextAttackDelay(1.45);
+		m_flNextPrimaryAttack = m_hPlayer->m_flNextAttack;
 		m_flNextSecondaryAttack = UTIL_WeaponTimeBase() + 1.0f;
 
 		return TRUE;
@@ -74,39 +74,39 @@ BOOL CAWP::Deploy()
 
 void CAWP::SecondaryAttack()
 {
-	switch (m_pPlayer->m_iFOV)
+	switch (m_hPlayer->m_iFOV)
 	{
-	case 90: m_pPlayer->m_iFOV = m_pPlayer->pev->fov = 40; break;
-	case 40: m_pPlayer->m_iFOV = m_pPlayer->pev->fov = 10; break;
-	default: m_pPlayer->m_iFOV = m_pPlayer->pev->fov = 90; break;
+	case 90: m_hPlayer->m_iFOV = m_hPlayer->pev->fov = 40; break;
+	case 40: m_hPlayer->m_iFOV = m_hPlayer->pev->fov = 10; break;
+	default: m_hPlayer->m_iFOV = m_hPlayer->pev->fov = 90; break;
 	}
 
 	if (TheBots)
 	{
-		TheBots->OnEvent(EVENT_WEAPON_ZOOMED, m_pPlayer);
+		TheBots->OnEvent(EVENT_WEAPON_ZOOMED, m_hPlayer);
 	}
 
-	m_pPlayer->ResetMaxSpeed();
-	EMIT_SOUND(m_pPlayer->edict(), CHAN_ITEM, "weapons/zoom.wav", 0.2, 2.4);
+	m_hPlayer->ResetMaxSpeed();
+	EMIT_SOUND(m_hPlayer->edict(), CHAN_ITEM, "weapons/zoom.wav", 0.2, 2.4);
 
 	m_flNextSecondaryAttack = UTIL_WeaponTimeBase() + 0.3;
 }
 
 void CAWP::PrimaryAttack()
 {
-	if (!(m_pPlayer->pev->flags & FL_ONGROUND))
+	if (!(m_hPlayer->pev->flags & FL_ONGROUND))
 	{
 		AWPFire(0.85, 1.45, FALSE);
 	}
-	else if (m_pPlayer->pev->velocity.Length2D() > 140)
+	else if (m_hPlayer->pev->velocity.Length2D() > 140)
 	{
 		AWPFire(0.25, 1.45, FALSE);
 	}
-	else if (m_pPlayer->pev->velocity.Length2D() > 10)
+	else if (m_hPlayer->pev->velocity.Length2D() > 10)
 	{
 		AWPFire(0.1, 1.45, FALSE);
 	}
-	else if (m_pPlayer->pev->flags & FL_DUCKING)
+	else if (m_hPlayer->pev->flags & FL_DUCKING)
 	{
 		AWPFire(0.0, 1.45, FALSE);
 	}
@@ -121,14 +121,14 @@ void CAWP::AWPFire(float flSpread, float flCycleTime, BOOL fUseAutoAim)
 	Vector vecAiming, vecSrc, vecDir;
 	int flag;
 
-	if (m_pPlayer->pev->fov != DEFAULT_FOV)
+	if (m_hPlayer->pev->fov != DEFAULT_FOV)
 	{
-		m_pPlayer->m_bResumeZoom = true;
-		m_pPlayer->m_iLastZoom = m_pPlayer->m_iFOV;
+		m_hPlayer->m_bResumeZoom = true;
+		m_hPlayer->m_iLastZoom = m_hPlayer->m_iFOV;
 
 		// reset a fov
-		m_pPlayer->m_iFOV = DEFAULT_FOV;
-		m_pPlayer->pev->fov = DEFAULT_FOV;
+		m_hPlayer->m_iFOV = DEFAULT_FOV;
+		m_hPlayer->pev->fov = DEFAULT_FOV;
 	}
 	// If we are not zoomed in, the bullet diverts more.
 	else
@@ -146,23 +146,23 @@ void CAWP::AWPFire(float flSpread, float flCycleTime, BOOL fUseAutoAim)
 
 		if (TheBots)
 		{
-			TheBots->OnEvent(EVENT_WEAPON_FIRED_ON_EMPTY, m_pPlayer);
+			TheBots->OnEvent(EVENT_WEAPON_FIRED_ON_EMPTY, m_hPlayer);
 		}
 
 		return;
 	}
 
 	m_iClip--;
-	m_pPlayer->pev->effects |= EF_MUZZLEFLASH;
-	m_pPlayer->SetAnimation(PLAYER_ATTACK1);
+	m_hPlayer->pev->effects |= EF_MUZZLEFLASH;
+	m_hPlayer->SetAnimation(PLAYER_ATTACK1);
 
-	UTIL_MakeVectors(m_pPlayer->pev->v_angle + m_pPlayer->pev->punchangle);
+	UTIL_MakeVectors(m_hPlayer->pev->v_angle + m_hPlayer->pev->punchangle);
 
-	m_pPlayer->m_flEjectBrass = gpGlobals->time + 0.55f;
-	m_pPlayer->m_iWeaponVolume = BIG_EXPLOSION_VOLUME;
-	m_pPlayer->m_iWeaponFlash = NORMAL_GUN_FLASH;
+	m_hPlayer->m_flEjectBrass = gpGlobals->time + 0.55f;
+	m_hPlayer->m_iWeaponVolume = BIG_EXPLOSION_VOLUME;
+	m_hPlayer->m_iWeaponFlash = NORMAL_GUN_FLASH;
 
-	vecSrc = m_pPlayer->GetGunPosition();
+	vecSrc = m_hPlayer->GetGunPosition();
 	vecAiming = gpGlobals->v_forward;
 
 #ifdef REGAMEDLL_API
@@ -170,7 +170,7 @@ void CAWP::AWPFire(float flSpread, float flCycleTime, BOOL fUseAutoAim)
 #else
 	float flBaseDamage = AWP_DAMAGE;
 #endif
-	vecDir = m_pPlayer->FireBullets3(vecSrc, vecAiming, flSpread, 8192, 3, BULLET_PLAYER_338MAG, flBaseDamage, AWP_RANGE_MODIFER, m_pPlayer->pev, true, m_pPlayer->random_seed);
+	vecDir = m_hPlayer->FireBullets3(vecSrc, vecAiming, flSpread, 8192, 3, BULLET_PLAYER_338MAG, flBaseDamage, AWP_RANGE_MODIFER, m_hPlayer->pev, true, m_hPlayer->random_seed);
 
 #ifdef CLIENT_WEAPONS
 	flag = FEV_NOTHOST;
@@ -178,33 +178,33 @@ void CAWP::AWPFire(float flSpread, float flCycleTime, BOOL fUseAutoAim)
 	flag = 0;
 #endif
 
-	PLAYBACK_EVENT_FULL(flag, m_pPlayer->edict(), m_usFireAWP, 0, (float *)&g_vecZero, (float *)&g_vecZero, vecDir.x, vecDir.y,
-		int(m_pPlayer->pev->punchangle.x * 100), int(m_pPlayer->pev->punchangle.x * 100), FALSE, FALSE);
+	PLAYBACK_EVENT_FULL(flag, m_hPlayer->edict(), m_usFireAWP, 0, (float *)&g_vecZero, (float *)&g_vecZero, vecDir.x, vecDir.y,
+		int(m_hPlayer->pev->punchangle.x * 100), int(m_hPlayer->pev->punchangle.x * 100), FALSE, FALSE);
 
 	m_flNextPrimaryAttack = m_flNextSecondaryAttack = GetNextAttackDelay(flCycleTime);
 
-	if (!m_iClip && m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType] <= 0)
+	if (!m_iClip && m_hPlayer->m_rgAmmo[m_iPrimaryAmmoType] <= 0)
 	{
-		m_pPlayer->SetSuitUpdate("!HEV_AMO0", SUIT_SENTENCE, SUIT_REPEAT_OK);
+		m_hPlayer->SetSuitUpdate("!HEV_AMO0", SUIT_SENTENCE, SUIT_REPEAT_OK);
 	}
 
 	m_flTimeWeaponIdle = UTIL_WeaponTimeBase() + 2.0f;
-	m_pPlayer->pev->punchangle.x -= 2.0f;
+	m_hPlayer->pev->punchangle.x -= 2.0f;
 }
 
 void CAWP::Reload()
 {
-	if (m_pPlayer->ammo_338mag <= 0)
+	if (m_hPlayer->ammo_338mag <= 0)
 		return;
 
 	if (DefaultReload(iMaxClip(), AWP_RELOAD, AWP_RELOAD_TIME))
 	{
-		m_pPlayer->SetAnimation(PLAYER_RELOAD);
+		m_hPlayer->SetAnimation(PLAYER_RELOAD);
 
-		if (m_pPlayer->pev->fov != DEFAULT_FOV)
+		if (m_hPlayer->pev->fov != DEFAULT_FOV)
 		{
-			m_pPlayer->m_iFOV = 10;
-			m_pPlayer->pev->fov = 10;
+			m_hPlayer->m_iFOV = 10;
+			m_hPlayer->pev->fov = 10;
 
 			SecondaryAttack();
 		}
@@ -214,7 +214,7 @@ void CAWP::Reload()
 void CAWP::WeaponIdle()
 {
 	ResetEmptySound();
-	m_pPlayer->GetAutoaimVector(AUTOAIM_10DEGREES);
+	m_hPlayer->GetAutoaimVector(AUTOAIM_10DEGREES);
 
 	if (m_flTimeWeaponIdle <= UTIL_WeaponTimeBase() && m_iClip)
 	{
@@ -225,7 +225,7 @@ void CAWP::WeaponIdle()
 
 float CAWP::GetMaxSpeed()
 {
-	if (m_pPlayer->m_iFOV == DEFAULT_FOV)
+	if (m_hPlayer->m_iFOV == DEFAULT_FOV)
 		return AWP_MAX_SPEED;
 
 	// Slower speed when zoomed in.

--- a/regamedll/dlls/wpn_shared/wpn_c4.cpp
+++ b/regamedll/dlls/wpn_shared/wpn_c4.cpp
@@ -64,10 +64,10 @@ BOOL CC4::Deploy()
 	m_bStartedArming = false;
 	m_fArmedTime = 0;
 
-	if (m_pPlayer->HasShield())
+	if (m_hPlayer->HasShield())
 	{
 		m_bHasShield = true;
-		m_pPlayer->pev->gamestate = HITGROUP_SHIELD_DISABLED;
+		m_hPlayer->pev->gamestate = HITGROUP_SHIELD_DISABLED;
 	}
 
 	return DefaultDeploy("models/v_c4.mdl", "models/p_c4.mdl", C4_DRAW, "c4", UseDecrement() != FALSE);
@@ -75,22 +75,22 @@ BOOL CC4::Deploy()
 
 void CC4::Holster(int skiplocal)
 {
-	m_pPlayer->m_flNextAttack = UTIL_WeaponTimeBase() + 0.5f;
+	m_hPlayer->m_flNextAttack = UTIL_WeaponTimeBase() + 0.5f;
 
 #ifdef REGAMEDLL_FIXES
 	if(m_bStartedArming)
 	{
-		m_pPlayer->SetProgressBarTime(0);
+		m_hPlayer->SetProgressBarTime(0);
 	}
 #endif
 
 	m_bStartedArming = false;	// stop arming sequence
 
-	if (!m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType])
+	if (!m_hPlayer->m_rgAmmo[m_iPrimaryAmmoType])
 	{
 #ifndef REGAMEDLL_FIXES
 		// Moved to DestroyItem()
-		m_pPlayer->pev->weapons &= ~(1 << WEAPON_C4);
+		m_hPlayer->pev->weapons &= ~(1 << WEAPON_C4);
 #endif
 
 		DestroyItem();
@@ -98,25 +98,25 @@ void CC4::Holster(int skiplocal)
 
 	if (m_bHasShield)
 	{
-		m_pPlayer->pev->gamestate = HITGROUP_SHIELD_ENABLED;
+		m_hPlayer->pev->gamestate = HITGROUP_SHIELD_ENABLED;
 		m_bHasShield = false;
 	}
 }
 
 void CC4::PrimaryAttack()
 {
-	if (m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType] <= 0)
+	if (m_hPlayer->m_rgAmmo[m_iPrimaryAmmoType] <= 0)
 		return;
 
-	int inBombZone = (m_pPlayer->m_signals.GetState() & SIGNAL_BOMB) == SIGNAL_BOMB;
-	int onGround = (m_pPlayer->pev->flags & FL_ONGROUND) == FL_ONGROUND;
+	int inBombZone = (m_hPlayer->m_signals.GetState() & SIGNAL_BOMB) == SIGNAL_BOMB;
+	int onGround = (m_hPlayer->pev->flags & FL_ONGROUND) == FL_ONGROUND;
 
 #ifdef REGAMEDLL_FIXES
 	if (!onGround)
 	{
 		TraceResult tr;
-		UTIL_TraceLine(m_pPlayer->pev->origin, m_pPlayer->pev->origin + Vector(0, 0, -8192), ignore_monsters, m_pPlayer->edict(), &tr);
-		onGround = (tr.flFraction != 1.0 && m_pPlayer->pev->velocity.z == 0.0f);
+		UTIL_TraceLine(m_hPlayer->pev->origin, m_hPlayer->pev->origin + Vector(0, 0, -8192), ignore_monsters, m_hPlayer->edict(), &tr);
+		onGround = (tr.flFraction != 1.0 && m_hPlayer->pev->velocity.z == 0.0f);
 	}
 #endif
 
@@ -126,14 +126,14 @@ void CC4::PrimaryAttack()
 	{
 		if (!inBombZone)
 		{
-			ClientPrint(m_pPlayer->pev, HUD_PRINTCENTER, "#C4_Plant_At_Bomb_Spot");
+			ClientPrint(m_hPlayer->pev, HUD_PRINTCENTER, "#C4_Plant_At_Bomb_Spot");
 			m_flNextPrimaryAttack = GetNextAttackDelay(1.0);
 			return;
 		}
 
 		if (!onGround)
 		{
-			ClientPrint(m_pPlayer->pev, HUD_PRINTCENTER, "#C4_Plant_Must_Be_On_Ground");
+			ClientPrint(m_hPlayer->pev, HUD_PRINTCENTER, "#C4_Plant_Must_Be_On_Ground");
 			m_flNextPrimaryAttack = GetNextAttackDelay(1.0);
 			return;
 		}
@@ -147,13 +147,13 @@ void CC4::PrimaryAttack()
 
 		// freeze the player in place while planting
 #ifdef REGAMEDLL_FIXES
-		m_pPlayer->ResetMaxSpeed();
+		m_hPlayer->ResetMaxSpeed();
 #else
-		SET_CLIENT_MAXSPEED(m_pPlayer->edict(), 1.0);
+		SET_CLIENT_MAXSPEED(m_hPlayer->edict(), 1.0);
 #endif
 
-		m_pPlayer->SetAnimation(PLAYER_ATTACK1);
-		m_pPlayer->SetProgressBarTime(C4_ARMING_ON_TIME);
+		m_hPlayer->SetAnimation(PLAYER_ATTACK1);
+		m_hPlayer->SetProgressBarTime(C4_ARMING_ON_TIME);
 	}
 	else
 	{
@@ -168,7 +168,7 @@ void CC4::PrimaryAttack()
 				m_fArmedTime = 0;
 
 				Broadcast("BOMBPL");
-				m_pPlayer->m_bHasC4 = false;
+				m_hPlayer->m_bHasC4 = false;
 
 				if (pev->speed != 0 && CSGameRules())
 				{
@@ -176,16 +176,16 @@ void CC4::PrimaryAttack()
 				}
 
 #ifdef REGAMEDLL_FIXES
-				Vector vBombAngles = Vector(0, m_pPlayer->pev->angles[1] - 90.0, 0);
+				Vector vBombAngles = Vector(0, m_hPlayer->pev->angles[1] - 90.0, 0);
 #else
 				Vector vBombAngles = Vector(0, 0, 0);
 #endif
-				CGrenade *pBomb = CGrenade::ShootSatchelCharge(m_pPlayer->pev, m_pPlayer->pev->origin, vBombAngles);
+				CGrenade *pBomb = CGrenade::ShootSatchelCharge(m_hPlayer->pev, m_hPlayer->pev->origin, vBombAngles);
 
 				MESSAGE_BEGIN(MSG_SPEC, SVC_DIRECTOR);
 					WRITE_BYTE(9);
 					WRITE_BYTE(DRC_CMD_EVENT);
-					WRITE_SHORT(m_pPlayer->entindex());
+					WRITE_SHORT(m_hPlayer->entindex());
 					WRITE_SHORT(0);
 					WRITE_LONG(DRC_FLAG_FACEPLAYER | 11);
 				MESSAGE_END();
@@ -200,18 +200,18 @@ void CC4::PrimaryAttack()
 				UTIL_ClientPrintAll(HUD_PRINTCENTER, "#Bomb_Planted");
 				if (TheBots)
 				{
-					TheBots->OnEvent(EVENT_BOMB_PLANTED, m_pPlayer, pBomb);
+					TheBots->OnEvent(EVENT_BOMB_PLANTED, m_hPlayer, pBomb);
 				}
 
-				if (TheCareerTasks && CSGameRules()->IsCareer() && !m_pPlayer->IsBot())
+				if (TheCareerTasks && CSGameRules()->IsCareer() && !m_hPlayer->IsBot())
 				{
-					TheCareerTasks->HandleEvent(EVENT_BOMB_PLANTED, m_pPlayer);
+					TheCareerTasks->HandleEvent(EVENT_BOMB_PLANTED, m_hPlayer);
 				}
 
 				UTIL_LogPrintf("\"%s<%i><%s><TERRORIST>\" triggered \"Planted_The_Bomb\"\n",
-					STRING(m_pPlayer->pev->netname),
-					GETPLAYERUSERID(m_pPlayer->edict()),
-					GETPLAYERAUTHID(m_pPlayer->edict()));
+					STRING(m_hPlayer->pev->netname),
+					GETPLAYERUSERID(m_hPlayer->edict()),
+					GETPLAYERAUTHID(m_hPlayer->edict()));
 
 				g_pGameRules->m_bBombDropped = FALSE;
 
@@ -219,15 +219,15 @@ void CC4::PrimaryAttack()
 				EMIT_SOUND(edict(), CHAN_WEAPON, "weapons/c4_plant.wav", VOL_NORM, ATTN_NORM);
 
 				// hide the backpack in Terrorist's models.
-				m_pPlayer->pev->body = 0;
+				m_hPlayer->pev->body = 0;
 
 				// release the player from being frozen
-				m_pPlayer->ResetMaxSpeed();
+				m_hPlayer->ResetMaxSpeed();
 
 				// No more c4!
-				m_pPlayer->SetBombIcon(FALSE);
+				m_hPlayer->SetBombIcon(FALSE);
 
-				if (--m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType] <= 0)
+				if (--m_hPlayer->m_rgAmmo[m_iPrimaryAmmoType] <= 0)
 				{
 					RetireWeapon();
 					return;
@@ -242,24 +242,24 @@ void CC4::PrimaryAttack()
 					SendWeaponAnim(C4_DROP, UseDecrement() != FALSE);
 
 					// player "place" animation
-					m_pPlayer->SetAnimation(PLAYER_HOLDBOMB);
+					m_hPlayer->SetAnimation(PLAYER_HOLDBOMB);
 				}
 			}
 		}
 		else
 		{
 			if (inBombZone)
-				ClientPrint(m_pPlayer->pev, HUD_PRINTCENTER, "#C4_Plant_Must_Be_On_Ground");
+				ClientPrint(m_hPlayer->pev, HUD_PRINTCENTER, "#C4_Plant_Must_Be_On_Ground");
 			else
-				ClientPrint(m_pPlayer->pev, HUD_PRINTCENTER, "#C4_Arming_Cancelled");
+				ClientPrint(m_hPlayer->pev, HUD_PRINTCENTER, "#C4_Arming_Cancelled");
 
 			m_bStartedArming = false;
 			m_flNextPrimaryAttack = GetNextAttackDelay(1.5);
 
 			// release the player from being frozen, we've somehow left the bomb zone
-			m_pPlayer->ResetMaxSpeed();
-			m_pPlayer->SetProgressBarTime(0);
-			m_pPlayer->SetAnimation(PLAYER_HOLDBOMB);
+			m_hPlayer->ResetMaxSpeed();
+			m_hPlayer->SetProgressBarTime(0);
+			m_hPlayer->SetAnimation(PLAYER_HOLDBOMB);
 
 			// this means the placement animation is canceled
 			if (m_bBombPlacedAnimation)
@@ -283,10 +283,10 @@ void CC4::WeaponIdle()
 		m_bStartedArming = false;
 
 		// release the player from being frozen
-		m_pPlayer->ResetMaxSpeed();
+		m_hPlayer->ResetMaxSpeed();
 
 		m_flNextPrimaryAttack = GetNextAttackDelay(1.0);
-		m_pPlayer->SetProgressBarTime(0);
+		m_hPlayer->SetProgressBarTime(0);
 
 		// this means the placement animation is canceled
 		if (m_bBombPlacedAnimation)
@@ -297,7 +297,7 @@ void CC4::WeaponIdle()
 
 	if (m_flTimeWeaponIdle <= UTIL_WeaponTimeBase())
 	{
-		if (m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType] <= 0)
+		if (m_hPlayer->m_rgAmmo[m_iPrimaryAmmoType] <= 0)
 		{
 			RetireWeapon();
 			return;
@@ -338,7 +338,7 @@ void CC4::KeyValue(KeyValueData *pkvd)
 void CC4::Use(CBaseEntity *pActivator, CBaseEntity *pCaller, USE_TYPE useType, float value)
 {
 #ifndef REGAMEDLL_FIXES
-	if (m_pPlayer)
+	if (m_hPlayer)
 		return;
 
 	CBasePlayer *pPlayer = UTIL_PlayerByIndex(1);

--- a/regamedll/dlls/wpn_shared/wpn_deagle.cpp
+++ b/regamedll/dlls/wpn_shared/wpn_deagle.cpp
@@ -63,9 +63,9 @@ BOOL CDEAGLE::Deploy()
 	m_flAccuracy = 0.9f;
 	m_fMaxSpeed = DEAGLE_MAX_SPEED;
 	m_iWeaponState &= ~WPNSTATE_SHIELD_DRAWN;
-	m_pPlayer->m_bShieldDrawn = false;
+	m_hPlayer->m_bShieldDrawn = false;
 
-	if (m_pPlayer->HasShield())
+	if (m_hPlayer->HasShield())
 		return DefaultDeploy("models/shield/v_shield_deagle.mdl", "models/shield/p_shield_deagle.mdl", DEAGLE_DRAW, "shieldgun", UseDecrement() != FALSE);
 	else
 		return DefaultDeploy("models/v_deagle.mdl", "models/p_deagle.mdl", DEAGLE_DRAW, "onehanded", UseDecrement() != FALSE);
@@ -73,15 +73,15 @@ BOOL CDEAGLE::Deploy()
 
 void CDEAGLE::PrimaryAttack()
 {
-	if (!(m_pPlayer->pev->flags & FL_ONGROUND))
+	if (!(m_hPlayer->pev->flags & FL_ONGROUND))
 	{
 		DEAGLEFire(1.5 * (1 - m_flAccuracy), 0.3, FALSE);
 	}
-	else if (m_pPlayer->pev->velocity.Length2D() > 0)
+	else if (m_hPlayer->pev->velocity.Length2D() > 0)
 	{
 		DEAGLEFire(0.25 * (1 - m_flAccuracy), 0.3, FALSE);
 	}
-	else if (m_pPlayer->pev->flags & FL_DUCKING)
+	else if (m_hPlayer->pev->flags & FL_DUCKING)
 	{
 		DEAGLEFire(0.115 * (1 - m_flAccuracy), 0.3, FALSE);
 	}
@@ -134,23 +134,23 @@ void CDEAGLE::DEAGLEFire(float flSpread, float flCycleTime, BOOL fUseSemi)
 
 		if (TheBots)
 		{
-			TheBots->OnEvent(EVENT_WEAPON_FIRED_ON_EMPTY, m_pPlayer);
+			TheBots->OnEvent(EVENT_WEAPON_FIRED_ON_EMPTY, m_hPlayer);
 		}
 
 		return;
 	}
 
 	m_iClip--;
-	m_pPlayer->pev->effects |= EF_MUZZLEFLASH;
+	m_hPlayer->pev->effects |= EF_MUZZLEFLASH;
 	SetPlayerShieldAnim();
 
-	m_pPlayer->SetAnimation(PLAYER_ATTACK1);
-	UTIL_MakeVectors(m_pPlayer->pev->v_angle + m_pPlayer->pev->punchangle);
+	m_hPlayer->SetAnimation(PLAYER_ATTACK1);
+	UTIL_MakeVectors(m_hPlayer->pev->v_angle + m_hPlayer->pev->punchangle);
 
-	m_pPlayer->m_iWeaponVolume = BIG_EXPLOSION_VOLUME;
-	m_pPlayer->m_iWeaponFlash = NORMAL_GUN_FLASH;
+	m_hPlayer->m_iWeaponVolume = BIG_EXPLOSION_VOLUME;
+	m_hPlayer->m_iWeaponFlash = NORMAL_GUN_FLASH;
 
-	vecSrc = m_pPlayer->GetGunPosition();
+	vecSrc = m_hPlayer->GetGunPosition();
 	vecAiming = gpGlobals->v_forward;
 
 #ifdef REGAMEDLL_API
@@ -158,7 +158,7 @@ void CDEAGLE::DEAGLEFire(float flSpread, float flCycleTime, BOOL fUseSemi)
 #else
 	float flBaseDamage = DEAGLE_DAMAGE;
 #endif
-	vecDir = m_pPlayer->FireBullets3(vecSrc, vecAiming, flSpread, 4096, 2, BULLET_PLAYER_50AE, flBaseDamage, DEAGLE_RANGE_MODIFER, m_pPlayer->pev, true, m_pPlayer->random_seed);
+	vecDir = m_hPlayer->FireBullets3(vecSrc, vecAiming, flSpread, 4096, 2, BULLET_PLAYER_50AE, flBaseDamage, DEAGLE_RANGE_MODIFER, m_hPlayer->pev, true, m_hPlayer->random_seed);
 
 #ifdef CLIENT_WEAPONS
 	flag = FEV_NOTHOST;
@@ -166,29 +166,29 @@ void CDEAGLE::DEAGLEFire(float flSpread, float flCycleTime, BOOL fUseSemi)
 	flag = 0;
 #endif
 
-	PLAYBACK_EVENT_FULL(flag, m_pPlayer->edict(), m_usFireDeagle, 0, (float *)&g_vecZero, (float *)&g_vecZero, vecDir.x, vecDir.y,
-		int(m_pPlayer->pev->punchangle.x * 100), int(m_pPlayer->pev->punchangle.y * 100), m_iClip == 0, FALSE);
+	PLAYBACK_EVENT_FULL(flag, m_hPlayer->edict(), m_usFireDeagle, 0, (float *)&g_vecZero, (float *)&g_vecZero, vecDir.x, vecDir.y,
+		int(m_hPlayer->pev->punchangle.x * 100), int(m_hPlayer->pev->punchangle.y * 100), m_iClip == 0, FALSE);
 
 	m_flNextPrimaryAttack = m_flNextSecondaryAttack = GetNextAttackDelay(flCycleTime);
 
-	if (!m_iClip && m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType] <= 0)
+	if (!m_iClip && m_hPlayer->m_rgAmmo[m_iPrimaryAmmoType] <= 0)
 	{
-		m_pPlayer->SetSuitUpdate("!HEV_AMO0", SUIT_SENTENCE, SUIT_REPEAT_OK);
+		m_hPlayer->SetSuitUpdate("!HEV_AMO0", SUIT_SENTENCE, SUIT_REPEAT_OK);
 	}
 
 	m_flTimeWeaponIdle = UTIL_WeaponTimeBase() + 1.8f;
-	m_pPlayer->pev->punchangle.x -= 2;
+	m_hPlayer->pev->punchangle.x -= 2;
 	ResetPlayerShieldAnim();
 }
 
 void CDEAGLE::Reload()
 {
-	if (m_pPlayer->ammo_50ae <= 0)
+	if (m_hPlayer->ammo_50ae <= 0)
 		return;
 
 	if (DefaultReload(iMaxClip(), DEAGLE_RELOAD, DEAGLE_RELOAD_TIME))
 	{
-		m_pPlayer->SetAnimation(PLAYER_RELOAD);
+		m_hPlayer->SetAnimation(PLAYER_RELOAD);
 		m_flAccuracy = 0.9f;
 	}
 }
@@ -196,7 +196,7 @@ void CDEAGLE::Reload()
 void CDEAGLE::WeaponIdle()
 {
 	ResetEmptySound();
-	m_pPlayer->GetAutoaimVector(AUTOAIM_10DEGREES);
+	m_hPlayer->GetAutoaimVector(AUTOAIM_10DEGREES);
 
 	if (m_flTimeWeaponIdle <= UTIL_WeaponTimeBase())
 	{

--- a/regamedll/dlls/wpn_shared/wpn_elite.cpp
+++ b/regamedll/dlls/wpn_shared/wpn_elite.cpp
@@ -73,15 +73,15 @@ BOOL CELITE::Deploy()
 
 void CELITE::PrimaryAttack()
 {
-	if (!(m_pPlayer->pev->flags & FL_ONGROUND))
+	if (!(m_hPlayer->pev->flags & FL_ONGROUND))
 	{
 		ELITEFire(1.3 * (1 - m_flAccuracy), 0.2, FALSE);
 	}
-	else if (m_pPlayer->pev->velocity.Length2D() > 0)
+	else if (m_hPlayer->pev->velocity.Length2D() > 0)
 	{
 		ELITEFire(0.175 * (1 - m_flAccuracy), 0.2, FALSE);
 	}
-	else if (m_pPlayer->pev->flags & FL_DUCKING)
+	else if (m_hPlayer->pev->flags & FL_DUCKING)
 	{
 		ELITEFire(0.08 * (1 - m_flAccuracy), 0.2, FALSE);
 	}
@@ -138,7 +138,7 @@ void CELITE::ELITEFire(float flSpread, float flCycleTime, BOOL fUseSemi)
 
 		if (TheBots)
 		{
-			TheBots->OnEvent(EVENT_WEAPON_FIRED_ON_EMPTY, m_pPlayer);
+			TheBots->OnEvent(EVENT_WEAPON_FIRED_ON_EMPTY, m_hPlayer);
 		}
 
 		return;
@@ -147,14 +147,14 @@ void CELITE::ELITEFire(float flSpread, float flCycleTime, BOOL fUseSemi)
 	m_flNextPrimaryAttack = m_flNextSecondaryAttack = GetNextAttackDelay(flCycleTime);
 
 	m_iClip--;
-	m_pPlayer->m_iWeaponVolume = BIG_EXPLOSION_VOLUME;
-	m_pPlayer->m_iWeaponFlash = DIM_GUN_FLASH;
+	m_hPlayer->m_iWeaponVolume = BIG_EXPLOSION_VOLUME;
+	m_hPlayer->m_iWeaponFlash = DIM_GUN_FLASH;
 
-	UTIL_MakeVectors(m_pPlayer->pev->v_angle + m_pPlayer->pev->punchangle);
+	UTIL_MakeVectors(m_hPlayer->pev->v_angle + m_hPlayer->pev->punchangle);
 
-	m_pPlayer->pev->effects |= EF_MUZZLEFLASH;
+	m_hPlayer->pev->effects |= EF_MUZZLEFLASH;
 
-	vecSrc = m_pPlayer->GetGunPosition();
+	vecSrc = m_hPlayer->GetGunPosition();
 	vecAiming = gpGlobals->v_forward;
 
 #ifdef CLIENT_WEAPONS
@@ -171,46 +171,46 @@ void CELITE::ELITEFire(float flSpread, float flCycleTime, BOOL fUseSemi)
 
 	if (m_iWeaponState & WPNSTATE_ELITE_LEFT)
 	{
-		m_pPlayer->SetAnimation(PLAYER_ATTACK1);
+		m_hPlayer->SetAnimation(PLAYER_ATTACK1);
 		m_iWeaponState &= ~WPNSTATE_ELITE_LEFT;
 
 		vecSrc -= gpGlobals->v_right * 5;
-		vecDir = m_pPlayer->FireBullets3(vecSrc, vecAiming, flSpread,
-			8192, BULLET_PLAYER_9MM, 1, flBaseDamage, ELITE_RANGE_MODIFER, m_pPlayer->pev, true, m_pPlayer->random_seed);
+		vecDir = m_hPlayer->FireBullets3(vecSrc, vecAiming, flSpread,
+			8192, BULLET_PLAYER_9MM, 1, flBaseDamage, ELITE_RANGE_MODIFER, m_hPlayer->pev, true, m_hPlayer->random_seed);
 
-		PLAYBACK_EVENT_FULL(flag, m_pPlayer->edict(), m_usFireELITE_LEFT, 0, (float *)&g_vecZero, (float *)&g_vecZero, flTimeDiff, vecDir.x,
+		PLAYBACK_EVENT_FULL(flag, m_hPlayer->edict(), m_usFireELITE_LEFT, 0, (float *)&g_vecZero, (float *)&g_vecZero, flTimeDiff, vecDir.x,
 			int(vecDir.y * 100), m_iClip, FALSE, FALSE);
 	}
 	else
 	{
-		m_pPlayer->SetAnimation(PLAYER_ATTACK2);
+		m_hPlayer->SetAnimation(PLAYER_ATTACK2);
 		m_iWeaponState |= WPNSTATE_ELITE_LEFT;
 
 		vecSrc += gpGlobals->v_right * 5;
-		vecDir = m_pPlayer->FireBullets3(vecSrc, vecAiming, flSpread,
-			8192, BULLET_PLAYER_9MM, 1, flBaseDamage, ELITE_RANGE_MODIFER, m_pPlayer->pev, true, m_pPlayer->random_seed);
+		vecDir = m_hPlayer->FireBullets3(vecSrc, vecAiming, flSpread,
+			8192, BULLET_PLAYER_9MM, 1, flBaseDamage, ELITE_RANGE_MODIFER, m_hPlayer->pev, true, m_hPlayer->random_seed);
 
-		PLAYBACK_EVENT_FULL(flag, m_pPlayer->edict(), m_usFireELITE_RIGHT, 0, (float *)&g_vecZero, (float *)&g_vecZero, flTimeDiff, vecDir.x,
+		PLAYBACK_EVENT_FULL(flag, m_hPlayer->edict(), m_usFireELITE_RIGHT, 0, (float *)&g_vecZero, (float *)&g_vecZero, flTimeDiff, vecDir.x,
 			int(vecDir.y * 100), m_iClip, FALSE, FALSE);
 	}
 
-	if (!m_iClip && m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType] <= 0)
+	if (!m_iClip && m_hPlayer->m_rgAmmo[m_iPrimaryAmmoType] <= 0)
 	{
-		m_pPlayer->SetSuitUpdate("!HEV_AMO0", SUIT_SENTENCE, SUIT_REPEAT_OK);
+		m_hPlayer->SetSuitUpdate("!HEV_AMO0", SUIT_SENTENCE, SUIT_REPEAT_OK);
 	}
 
 	m_flTimeWeaponIdle = UTIL_WeaponTimeBase() + 2.0f;
-	m_pPlayer->pev->punchangle.x -= 2.0f;
+	m_hPlayer->pev->punchangle.x -= 2.0f;
 }
 
 void CELITE::Reload()
 {
-	if (m_pPlayer->ammo_9mm <= 0)
+	if (m_hPlayer->ammo_9mm <= 0)
 		return;
 
 	if (DefaultReload(iMaxClip(), ELITE_RELOAD, ELITE_RELOAD_TIME))
 	{
-		m_pPlayer->SetAnimation(PLAYER_RELOAD);
+		m_hPlayer->SetAnimation(PLAYER_RELOAD);
 		m_flAccuracy = 0.88f;
 	}
 }
@@ -218,7 +218,7 @@ void CELITE::Reload()
 void CELITE::WeaponIdle()
 {
 	ResetEmptySound();
-	m_pPlayer->GetAutoaimVector(AUTOAIM_10DEGREES);
+	m_hPlayer->GetAutoaimVector(AUTOAIM_10DEGREES);
 
 	if (m_flTimeWeaponIdle <= UTIL_WeaponTimeBase())
 	{

--- a/regamedll/dlls/wpn_shared/wpn_famas.cpp
+++ b/regamedll/dlls/wpn_shared/wpn_famas.cpp
@@ -76,12 +76,12 @@ void CFamas::SecondaryAttack()
 {
 	if (m_iWeaponState & WPNSTATE_FAMAS_BURST_MODE)
 	{
-		ClientPrint(m_pPlayer->pev, HUD_PRINTCENTER, "#Switch_To_FullAuto");
+		ClientPrint(m_hPlayer->pev, HUD_PRINTCENTER, "#Switch_To_FullAuto");
 		m_iWeaponState &= ~WPNSTATE_FAMAS_BURST_MODE;
 	}
 	else
 	{
-		ClientPrint(m_pPlayer->pev, HUD_PRINTCENTER, "#Switch_To_BurstFire");
+		ClientPrint(m_hPlayer->pev, HUD_PRINTCENTER, "#Switch_To_BurstFire");
 		m_iWeaponState |= WPNSTATE_FAMAS_BURST_MODE;
 	}
 
@@ -92,11 +92,11 @@ void CFamas::PrimaryAttack()
 {
 	bool bFireBurst = (m_iWeaponState & WPNSTATE_FAMAS_BURST_MODE) == WPNSTATE_FAMAS_BURST_MODE;
 
-	if (!(m_pPlayer->pev->flags & FL_ONGROUND))
+	if (!(m_hPlayer->pev->flags & FL_ONGROUND))
 	{
 		FamasFire(0.030 + 0.3 * m_flAccuracy, 0.0825, FALSE, bFireBurst);
 	}
-	else if (m_pPlayer->pev->velocity.Length2D() > 140)
+	else if (m_hPlayer->pev->velocity.Length2D() > 140)
 	{
 		FamasFire(0.030 + 0.07 * m_flAccuracy, 0.0825, FALSE, bFireBurst);
 	}
@@ -139,22 +139,22 @@ void CFamas::FamasFire(float flSpread, float flCycleTime, BOOL fUseAutoAim, BOOL
 
 		if (TheBots)
 		{
-			TheBots->OnEvent(EVENT_WEAPON_FIRED_ON_EMPTY, m_pPlayer);
+			TheBots->OnEvent(EVENT_WEAPON_FIRED_ON_EMPTY, m_hPlayer);
 		}
 
 		return;
 	}
 
 	m_iClip--;
-	m_pPlayer->pev->effects |= EF_MUZZLEFLASH;
-	m_pPlayer->SetAnimation(PLAYER_ATTACK1);
+	m_hPlayer->pev->effects |= EF_MUZZLEFLASH;
+	m_hPlayer->SetAnimation(PLAYER_ATTACK1);
 
-	UTIL_MakeVectors(m_pPlayer->pev->v_angle + m_pPlayer->pev->punchangle);
+	UTIL_MakeVectors(m_hPlayer->pev->v_angle + m_hPlayer->pev->punchangle);
 
-	m_pPlayer->m_iWeaponVolume = NORMAL_GUN_VOLUME;
-	m_pPlayer->m_iWeaponFlash = BRIGHT_GUN_FLASH;
+	m_hPlayer->m_iWeaponVolume = NORMAL_GUN_VOLUME;
+	m_hPlayer->m_iWeaponFlash = BRIGHT_GUN_FLASH;
 
-	vecSrc = m_pPlayer->GetGunPosition();
+	vecSrc = m_hPlayer->GetGunPosition();
 	vecAiming = gpGlobals->v_forward;
 
 #ifdef REGAMEDLL_API
@@ -162,8 +162,8 @@ void CFamas::FamasFire(float flSpread, float flCycleTime, BOOL fUseAutoAim, BOOL
 #else
 	float flBaseDamage = bFireBurst ? FAMAS_DAMAGE_BURST : FAMAS_DAMAGE;
 #endif
-	vecDir = m_pPlayer->FireBullets3(vecSrc, vecAiming, flSpread, 8192, 2, BULLET_PLAYER_556MM,
-		flBaseDamage, FAMAS_RANGE_MODIFER, m_pPlayer->pev, false, m_pPlayer->random_seed);
+	vecDir = m_hPlayer->FireBullets3(vecSrc, vecAiming, flSpread, 8192, 2, BULLET_PLAYER_556MM,
+		flBaseDamage, FAMAS_RANGE_MODIFER, m_hPlayer->pev, false, m_hPlayer->random_seed);
 
 #ifdef CLIENT_WEAPONS
 	flag = FEV_NOTHOST;
@@ -173,31 +173,31 @@ void CFamas::FamasFire(float flSpread, float flCycleTime, BOOL fUseAutoAim, BOOL
 
 #ifdef REGAMEDLL_ADD
 		// HACKHACK: client-side weapon prediction fix
-		if (!(iFlags() & ITEM_FLAG_NOFIREUNDERWATER) && m_pPlayer->pev->waterlevel == 3)
+		if (!(iFlags() & ITEM_FLAG_NOFIREUNDERWATER) && m_hPlayer->pev->waterlevel == 3)
 			flag = 0;
 #endif
 
-	PLAYBACK_EVENT_FULL(flag, m_pPlayer->edict(), m_usFireFamas, 0, (float *)&g_vecZero, (float *)&g_vecZero, vecDir.x, vecDir.y,
-		int(m_pPlayer->pev->punchangle.x * 10000000), int(m_pPlayer->pev->punchangle.y * 10000000), FALSE, FALSE);
+	PLAYBACK_EVENT_FULL(flag, m_hPlayer->edict(), m_usFireFamas, 0, (float *)&g_vecZero, (float *)&g_vecZero, vecDir.x, vecDir.y,
+		int(m_hPlayer->pev->punchangle.x * 10000000), int(m_hPlayer->pev->punchangle.y * 10000000), FALSE, FALSE);
 
 	m_flNextPrimaryAttack = m_flNextSecondaryAttack = GetNextAttackDelay(flCycleTime);
 
-	if (!m_iClip && m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType] <= 0)
+	if (!m_iClip && m_hPlayer->m_rgAmmo[m_iPrimaryAmmoType] <= 0)
 	{
-		m_pPlayer->SetSuitUpdate("!HEV_AMO0", SUIT_SENTENCE, SUIT_REPEAT_OK);
+		m_hPlayer->SetSuitUpdate("!HEV_AMO0", SUIT_SENTENCE, SUIT_REPEAT_OK);
 	}
 
 	m_flTimeWeaponIdle = UTIL_WeaponTimeBase() + 1.1f;
 
-	if (m_pPlayer->pev->velocity.Length2D() > 0)
+	if (m_hPlayer->pev->velocity.Length2D() > 0)
 	{
 		KickBack(1.0, 0.45, 0.275, 0.05, 4.0, 2.5, 7);
 	}
-	else if (!(m_pPlayer->pev->flags & FL_ONGROUND))
+	else if (!(m_hPlayer->pev->flags & FL_ONGROUND))
 	{
 		KickBack(1.25, 0.45, 0.22, 0.18, 5.5, 4.0, 5);
 	}
-	else if (m_pPlayer->pev->flags & FL_DUCKING)
+	else if (m_hPlayer->pev->flags & FL_DUCKING)
 	{
 		KickBack(0.575, 0.325, 0.2, 0.011, 3.25, 2.0, 8);
 	}
@@ -216,14 +216,14 @@ void CFamas::FamasFire(float flSpread, float flCycleTime, BOOL fUseAutoAim, BOOL
 
 void CFamas::Reload()
 {
-	if (m_pPlayer->ammo_556nato <= 0)
+	if (m_hPlayer->ammo_556nato <= 0)
 		return;
 
 	if (DefaultReload(iMaxClip(), FAMAS_RELOAD, FAMAS_RELOAD_TIME))
 	{
-		m_pPlayer->SetAnimation(PLAYER_RELOAD);
+		m_hPlayer->SetAnimation(PLAYER_RELOAD);
 
-		if (m_pPlayer->m_iFOV != DEFAULT_FOV)
+		if (m_hPlayer->m_iFOV != DEFAULT_FOV)
 		{
 			SecondaryAttack();
 		}
@@ -237,7 +237,7 @@ void CFamas::Reload()
 void CFamas::WeaponIdle()
 {
 	ResetEmptySound();
-	m_pPlayer->GetAutoaimVector(AUTOAIM_10DEGREES);
+	m_hPlayer->GetAutoaimVector(AUTOAIM_10DEGREES);
 
 	if (m_flTimeWeaponIdle <= UTIL_WeaponTimeBase())
 	{

--- a/regamedll/dlls/wpn_shared/wpn_fiveseven.cpp
+++ b/regamedll/dlls/wpn_shared/wpn_fiveseven.cpp
@@ -62,9 +62,9 @@ BOOL CFiveSeven::Deploy()
 	m_flAccuracy = 0.92f;
 	m_fMaxSpeed = FIVESEVEN_MAX_SPEED;
 	m_iWeaponState &= ~WPNSTATE_SHIELD_DRAWN;
-	m_pPlayer->m_bShieldDrawn = false;
+	m_hPlayer->m_bShieldDrawn = false;
 
-	if (m_pPlayer->HasShield())
+	if (m_hPlayer->HasShield())
 		return DefaultDeploy("models/shield/v_shield_fiveseven.mdl", "models/shield/p_shield_fiveseven.mdl", FIVESEVEN_DRAW, "shieldgun", UseDecrement() != FALSE);
 	else
 		return DefaultDeploy("models/v_fiveseven.mdl", "models/p_fiveseven.mdl", FIVESEVEN_DRAW, "onehanded", UseDecrement() != FALSE);
@@ -72,15 +72,15 @@ BOOL CFiveSeven::Deploy()
 
 void CFiveSeven::PrimaryAttack()
 {
-	if (!(m_pPlayer->pev->flags & FL_ONGROUND))
+	if (!(m_hPlayer->pev->flags & FL_ONGROUND))
 	{
 		FiveSevenFire(1.5 * (1 - m_flAccuracy), 0.2, FALSE);
 	}
-	else if (m_pPlayer->pev->velocity.Length2D() > 0)
+	else if (m_hPlayer->pev->velocity.Length2D() > 0)
 	{
 		FiveSevenFire(0.255 * (1 - m_flAccuracy), 0.2, FALSE);
 	}
-	else if (m_pPlayer->pev->flags & FL_DUCKING)
+	else if (m_hPlayer->pev->flags & FL_DUCKING)
 	{
 		FiveSevenFire(0.075 * (1 - m_flAccuracy), 0.2, FALSE);
 	}
@@ -133,23 +133,23 @@ void CFiveSeven::FiveSevenFire(float flSpread, float flCycleTime, BOOL fUseSemi)
 
 		if (TheBots)
 		{
-			TheBots->OnEvent(EVENT_WEAPON_FIRED_ON_EMPTY, m_pPlayer);
+			TheBots->OnEvent(EVENT_WEAPON_FIRED_ON_EMPTY, m_hPlayer);
 		}
 
 		return;
 	}
 
 	m_iClip--;
-	m_pPlayer->pev->effects |= EF_MUZZLEFLASH;
+	m_hPlayer->pev->effects |= EF_MUZZLEFLASH;
 	SetPlayerShieldAnim();
 
-	m_pPlayer->SetAnimation(PLAYER_ATTACK1);
-	UTIL_MakeVectors(m_pPlayer->pev->v_angle + m_pPlayer->pev->punchangle);
+	m_hPlayer->SetAnimation(PLAYER_ATTACK1);
+	UTIL_MakeVectors(m_hPlayer->pev->v_angle + m_hPlayer->pev->punchangle);
 
-	m_pPlayer->m_iWeaponVolume = BIG_EXPLOSION_VOLUME;
-	m_pPlayer->m_iWeaponFlash = DIM_GUN_FLASH;
+	m_hPlayer->m_iWeaponVolume = BIG_EXPLOSION_VOLUME;
+	m_hPlayer->m_iWeaponFlash = DIM_GUN_FLASH;
 
-	vecSrc = m_pPlayer->GetGunPosition();
+	vecSrc = m_hPlayer->GetGunPosition();
 	vecAiming = gpGlobals->v_forward;
 
 #ifdef REGAMEDLL_API
@@ -157,7 +157,7 @@ void CFiveSeven::FiveSevenFire(float flSpread, float flCycleTime, BOOL fUseSemi)
 #else
 	float flBaseDamage = FIVESEVEN_DAMAGE;
 #endif
-	vecDir = m_pPlayer->FireBullets3(vecSrc, vecAiming, flSpread, 4096, 1, BULLET_PLAYER_57MM, flBaseDamage, FIVESEVEN_RANGE_MODIFER, m_pPlayer->pev, false, m_pPlayer->random_seed);
+	vecDir = m_hPlayer->FireBullets3(vecSrc, vecAiming, flSpread, 4096, 1, BULLET_PLAYER_57MM, flBaseDamage, FIVESEVEN_RANGE_MODIFER, m_hPlayer->pev, false, m_hPlayer->random_seed);
 
 #ifdef CLIENT_WEAPONS
 	flag = FEV_NOTHOST;
@@ -165,29 +165,29 @@ void CFiveSeven::FiveSevenFire(float flSpread, float flCycleTime, BOOL fUseSemi)
 	flag = 0;
 #endif
 
-	PLAYBACK_EVENT_FULL(flag, m_pPlayer->edict(), m_usFireFiveSeven, 0, (float *)&g_vecZero, (float *)&g_vecZero, vecDir.x, vecDir.y,
-		int(m_pPlayer->pev->punchangle.x * 100), int(m_pPlayer->pev->punchangle.y * 100), m_iClip == 0, FALSE);
+	PLAYBACK_EVENT_FULL(flag, m_hPlayer->edict(), m_usFireFiveSeven, 0, (float *)&g_vecZero, (float *)&g_vecZero, vecDir.x, vecDir.y,
+		int(m_hPlayer->pev->punchangle.x * 100), int(m_hPlayer->pev->punchangle.y * 100), m_iClip == 0, FALSE);
 
 	m_flNextPrimaryAttack = m_flNextSecondaryAttack = GetNextAttackDelay(flCycleTime);
 
-	if (!m_iClip && m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType] <= 0)
+	if (!m_iClip && m_hPlayer->m_rgAmmo[m_iPrimaryAmmoType] <= 0)
 	{
-		m_pPlayer->SetSuitUpdate("!HEV_AMO0", SUIT_SENTENCE, SUIT_REPEAT_OK);
+		m_hPlayer->SetSuitUpdate("!HEV_AMO0", SUIT_SENTENCE, SUIT_REPEAT_OK);
 	}
 
 	m_flTimeWeaponIdle = UTIL_WeaponTimeBase() + 2.0f;
-	m_pPlayer->pev->punchangle.x -= 2.0f;
+	m_hPlayer->pev->punchangle.x -= 2.0f;
 	ResetPlayerShieldAnim();
 }
 
 void CFiveSeven::Reload()
 {
-	if (m_pPlayer->ammo_57mm <= 0)
+	if (m_hPlayer->ammo_57mm <= 0)
 		return;
 
 	if (DefaultReload(iMaxClip(), FIVESEVEN_RELOAD, FIVESEVEN_RELOAD_TIME))
 	{
-		m_pPlayer->SetAnimation(PLAYER_RELOAD);
+		m_hPlayer->SetAnimation(PLAYER_RELOAD);
 		m_flAccuracy = 0.92f;
 	}
 }
@@ -195,14 +195,14 @@ void CFiveSeven::Reload()
 void CFiveSeven::WeaponIdle()
 {
 	ResetEmptySound();
-	m_pPlayer->GetAutoaimVector(AUTOAIM_10DEGREES);
+	m_hPlayer->GetAutoaimVector(AUTOAIM_10DEGREES);
 
 	if (m_flTimeWeaponIdle > UTIL_WeaponTimeBase())
 	{
 		return;
 	}
 
-	if (m_pPlayer->HasShield())
+	if (m_hPlayer->HasShield())
 	{
 		m_flTimeWeaponIdle = UTIL_WeaponTimeBase() + 20.0f;
 

--- a/regamedll/dlls/wpn_shared/wpn_flashbang.cpp
+++ b/regamedll/dlls/wpn_shared/wpn_flashbang.cpp
@@ -60,9 +60,9 @@ BOOL CFlashbang::Deploy()
 	m_fMaxSpeed = FLASHBANG_MAX_SPEED;
 
 	m_iWeaponState &= ~WPNSTATE_SHIELD_DRAWN;
-	m_pPlayer->m_bShieldDrawn = false;
+	m_hPlayer->m_bShieldDrawn = false;
 
-	if (m_pPlayer->HasShield())
+	if (m_hPlayer->HasShield())
 		return DefaultDeploy("models/shield/v_shield_flashbang.mdl", "models/shield/p_shield_flashbang.mdl", FLASHBANG_DRAW, "shieldgren", UseDecrement() != FALSE);
 	else
 		return DefaultDeploy("models/v_flashbang.mdl", "models/p_flashbang.mdl", FLASHBANG_DRAW, "grenade", UseDecrement() != FALSE);
@@ -70,13 +70,13 @@ BOOL CFlashbang::Deploy()
 
 void CFlashbang::Holster(int skiplocal)
 {
-	m_pPlayer->m_flNextAttack = UTIL_WeaponTimeBase() + 0.5f;
+	m_hPlayer->m_flNextAttack = UTIL_WeaponTimeBase() + 0.5f;
 
-	if (!m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType])
+	if (!m_hPlayer->m_rgAmmo[m_iPrimaryAmmoType])
 	{
 #ifndef REGAMEDLL_FIXES
 		// Moved to DestroyItem()
-		m_pPlayer->pev->weapons &= ~(1 << WEAPON_FLASHBANG);
+		m_hPlayer->pev->weapons &= ~(1 << WEAPON_FLASHBANG);
 #endif
 		DestroyItem();
 	}
@@ -92,7 +92,7 @@ void CFlashbang::PrimaryAttack()
 		return;
 	}
 
-	if (!m_flStartThrow && m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType] > 0)
+	if (!m_flStartThrow && m_hPlayer->m_rgAmmo[m_iPrimaryAmmoType] > 0)
 	{
 		m_flReleaseThrow = 0;
 		m_flStartThrow = gpGlobals->time;
@@ -104,7 +104,7 @@ void CFlashbang::PrimaryAttack()
 
 bool CFlashbang::ShieldSecondaryFire(int iUpAnim, int iDownAnim)
 {
-	if (!m_pPlayer->HasShield() || m_flStartThrow > 0)
+	if (!m_hPlayer->HasShield() || m_flStartThrow > 0)
 	{
 		return false;
 	}
@@ -114,24 +114,24 @@ bool CFlashbang::ShieldSecondaryFire(int iUpAnim, int iDownAnim)
 		m_iWeaponState &= ~WPNSTATE_SHIELD_DRAWN;
 		SendWeaponAnim(iDownAnim, UseDecrement() != FALSE);
 
-		Q_strcpy(m_pPlayer->m_szAnimExtention, "shieldgren");
+		Q_strcpy(m_hPlayer->m_szAnimExtention, "shieldgren");
 
 		m_fMaxSpeed = FLASHBANG_MAX_SPEED;
-		m_pPlayer->m_bShieldDrawn = false;
+		m_hPlayer->m_bShieldDrawn = false;
 	}
 	else
 	{
 		m_iWeaponState |= WPNSTATE_SHIELD_DRAWN;
 		SendWeaponAnim(iUpAnim, UseDecrement() != FALSE);
 
-		Q_strcpy(m_pPlayer->m_szAnimExtention, "shielded");
+		Q_strcpy(m_hPlayer->m_szAnimExtention, "shielded");
 
 		m_fMaxSpeed = FLASHBANG_MAX_SPEED_SHIELD;
-		m_pPlayer->m_bShieldDrawn = true;
+		m_hPlayer->m_bShieldDrawn = true;
 	}
 
-	m_pPlayer->UpdateShieldCrosshair((m_iWeaponState & WPNSTATE_SHIELD_DRAWN) != WPNSTATE_SHIELD_DRAWN);
-	m_pPlayer->ResetMaxSpeed();
+	m_hPlayer->UpdateShieldCrosshair((m_iWeaponState & WPNSTATE_SHIELD_DRAWN) != WPNSTATE_SHIELD_DRAWN);
+	m_hPlayer->ResetMaxSpeed();
 
 	m_flNextSecondaryAttack = UTIL_WeaponTimeBase() + 0.4f;
 	m_flNextPrimaryAttack = GetNextAttackDelay(0.4);
@@ -147,23 +147,23 @@ void CFlashbang::SecondaryAttack()
 
 void CFlashbang::SetPlayerShieldAnim()
 {
-	if (!m_pPlayer->HasShield())
+	if (!m_hPlayer->HasShield())
 		return;
 
 	if (m_iWeaponState & WPNSTATE_SHIELD_DRAWN)
-		Q_strcpy(m_pPlayer->m_szAnimExtention, "shield");
+		Q_strcpy(m_hPlayer->m_szAnimExtention, "shield");
 	else
-		Q_strcpy(m_pPlayer->m_szAnimExtention, "shieldgren");
+		Q_strcpy(m_hPlayer->m_szAnimExtention, "shieldgren");
 }
 
 void CFlashbang::ResetPlayerShieldAnim()
 {
-	if (!m_pPlayer->HasShield())
+	if (!m_hPlayer->HasShield())
 		return;
 
 	if (m_iWeaponState & WPNSTATE_SHIELD_DRAWN)
 	{
-		Q_strcpy(m_pPlayer->m_szAnimExtention, "shieldgren");
+		Q_strcpy(m_hPlayer->m_szAnimExtention, "shieldgren");
 	}
 }
 
@@ -177,9 +177,9 @@ void CFlashbang::WeaponIdle()
 
 	if (m_flStartThrow)
 	{
-		m_pPlayer->Radio("%!MRAD_FIREINHOLE", "#Fire_in_the_hole");
+		m_hPlayer->Radio("%!MRAD_FIREINHOLE", "#Fire_in_the_hole");
 
-		Vector angThrow = m_pPlayer->pev->v_angle + m_pPlayer->pev->punchangle;
+		Vector angThrow = m_hPlayer->pev->v_angle + m_hPlayer->pev->punchangle;
 
 		if (angThrow.x < 0)
 			angThrow.x = -10 + angThrow.x * ((90 - 10) / 90.0);
@@ -193,22 +193,22 @@ void CFlashbang::WeaponIdle()
 
 		UTIL_MakeVectors(angThrow);
 
-		Vector vecSrc = m_pPlayer->pev->origin + m_pPlayer->pev->view_ofs + gpGlobals->v_forward * 16;
-		Vector vecThrow = gpGlobals->v_forward * flVel + m_pPlayer->pev->velocity;
+		Vector vecSrc = m_hPlayer->pev->origin + m_hPlayer->pev->view_ofs + gpGlobals->v_forward * 16;
+		Vector vecThrow = gpGlobals->v_forward * flVel + m_hPlayer->pev->velocity;
 
-		m_pPlayer->ThrowGrenade(this, vecSrc, vecThrow, 1.5);
+		m_hPlayer->ThrowGrenade(this, vecSrc, vecThrow, 1.5);
 
 		SendWeaponAnim(FLASHBANG_THROW, UseDecrement() != FALSE);
 		SetPlayerShieldAnim();
 
 		// player "shoot" animation
-		m_pPlayer->SetAnimation(PLAYER_ATTACK1);
+		m_hPlayer->SetAnimation(PLAYER_ATTACK1);
 
 		m_flStartThrow = 0;
 		m_flNextPrimaryAttack = GetNextAttackDelay(0.5);
 		m_flTimeWeaponIdle = UTIL_WeaponTimeBase() + 0.75f;
 
-		if (--m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType] <= 0)
+		if (--m_hPlayer->m_rgAmmo[m_iPrimaryAmmoType] <= 0)
 		{
 			// just threw last grenade
 			// set attack times in the future, and weapon idle in the future so we can see the whole throw
@@ -225,12 +225,12 @@ void CFlashbang::WeaponIdle()
 		m_flStartThrow = 0;
 		RetireWeapon();
 	}
-	else if (m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType])
+	else if (m_hPlayer->m_rgAmmo[m_iPrimaryAmmoType])
 	{
 		int iAnim;
 		float flRand = RANDOM_FLOAT(0, 1);
 
-		if (m_pPlayer->HasShield())
+		if (m_hPlayer->HasShield())
 		{
 			m_flTimeWeaponIdle = UTIL_WeaponTimeBase() + 20.0f;
 
@@ -268,5 +268,5 @@ LINK_HOOK_CLASS_CHAIN3(BOOL, CBasePlayerWeapon, CFlashbang, CanDeploy)
 
 BOOL EXT_FUNC CFlashbang::__API_HOOK(CanDeploy)()
 {
-	return m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType] != 0;
+	return m_hPlayer->m_rgAmmo[m_iPrimaryAmmoType] != 0;
 }

--- a/regamedll/dlls/wpn_shared/wpn_g3sg1.cpp
+++ b/regamedll/dlls/wpn_shared/wpn_g3sg1.cpp
@@ -63,40 +63,40 @@ BOOL CG3SG1::Deploy()
 
 void CG3SG1::SecondaryAttack()
 {
-	switch (m_pPlayer->m_iFOV)
+	switch (m_hPlayer->m_iFOV)
 	{
-	case 90: m_pPlayer->m_iFOV = m_pPlayer->pev->fov = 40; break;
-	case 40: m_pPlayer->m_iFOV = m_pPlayer->pev->fov = 15; break;
+	case 90: m_hPlayer->m_iFOV = m_hPlayer->pev->fov = 40; break;
+	case 40: m_hPlayer->m_iFOV = m_hPlayer->pev->fov = 15; break;
 #ifdef REGAMEDLL_FIXES
 	default:
 #else
 	case 15:
 #endif
-		m_pPlayer->m_iFOV = m_pPlayer->pev->fov = 90; break;
+		m_hPlayer->m_iFOV = m_hPlayer->pev->fov = 90; break;
 	}
 
-	m_pPlayer->ResetMaxSpeed();
+	m_hPlayer->ResetMaxSpeed();
 
 	if (TheBots)
 	{
-		TheBots->OnEvent(EVENT_WEAPON_ZOOMED, m_pPlayer);
+		TheBots->OnEvent(EVENT_WEAPON_ZOOMED, m_hPlayer);
 	}
 
-	EMIT_SOUND(m_pPlayer->edict(), CHAN_ITEM, "weapons/zoom.wav", 0.2, 2.4);
+	EMIT_SOUND(m_hPlayer->edict(), CHAN_ITEM, "weapons/zoom.wav", 0.2, 2.4);
 	m_flNextSecondaryAttack = UTIL_WeaponTimeBase() + 0.3f;
 }
 
 void CG3SG1::PrimaryAttack()
 {
-	if (!(m_pPlayer->pev->flags & FL_ONGROUND))
+	if (!(m_hPlayer->pev->flags & FL_ONGROUND))
 	{
 		G3SG1Fire(0.45, 0.25, FALSE);
 	}
-	else if (m_pPlayer->pev->velocity.Length2D() > 0)
+	else if (m_hPlayer->pev->velocity.Length2D() > 0)
 	{
 		G3SG1Fire(0.15, 0.25, FALSE);
 	}
-	else if (m_pPlayer->pev->flags & FL_DUCKING)
+	else if (m_hPlayer->pev->flags & FL_DUCKING)
 	{
 		G3SG1Fire(0.035, 0.25, FALSE);
 	}
@@ -111,7 +111,7 @@ void CG3SG1::G3SG1Fire(float flSpread, float flCycleTime, BOOL fUseAutoAim)
 	Vector vecAiming, vecSrc, vecDir;
 	int flag;
 
-	if (m_pPlayer->pev->fov == DEFAULT_FOV)
+	if (m_hPlayer->pev->fov == DEFAULT_FOV)
 	{
 		flSpread += 0.025f;
 	}
@@ -142,22 +142,22 @@ void CG3SG1::G3SG1Fire(float flSpread, float flCycleTime, BOOL fUseAutoAim)
 
 		if (TheBots)
 		{
-			TheBots->OnEvent(EVENT_WEAPON_FIRED_ON_EMPTY, m_pPlayer);
+			TheBots->OnEvent(EVENT_WEAPON_FIRED_ON_EMPTY, m_hPlayer);
 		}
 
 		return;
 	}
 
 	m_iClip--;
-	m_pPlayer->pev->effects |= EF_MUZZLEFLASH;
-	m_pPlayer->SetAnimation(PLAYER_ATTACK1);
+	m_hPlayer->pev->effects |= EF_MUZZLEFLASH;
+	m_hPlayer->SetAnimation(PLAYER_ATTACK1);
 
-	UTIL_MakeVectors(m_pPlayer->pev->v_angle + m_pPlayer->pev->punchangle);
+	UTIL_MakeVectors(m_hPlayer->pev->v_angle + m_hPlayer->pev->punchangle);
 
-	m_pPlayer->m_iWeaponVolume = BIG_EXPLOSION_VOLUME;
-	m_pPlayer->m_iWeaponFlash = NORMAL_GUN_FLASH;
+	m_hPlayer->m_iWeaponVolume = BIG_EXPLOSION_VOLUME;
+	m_hPlayer->m_iWeaponFlash = NORMAL_GUN_FLASH;
 
-	vecSrc = m_pPlayer->GetGunPosition();
+	vecSrc = m_hPlayer->GetGunPosition();
 	vecAiming = gpGlobals->v_forward;
 
 #ifdef REGAMEDLL_API
@@ -165,7 +165,7 @@ void CG3SG1::G3SG1Fire(float flSpread, float flCycleTime, BOOL fUseAutoAim)
 #else
 	float flBaseDamage = G3SG1_DAMAGE;
 #endif
-	vecDir = m_pPlayer->FireBullets3(vecSrc, vecAiming, (1 - m_flAccuracy) * flSpread, 8192, 3, BULLET_PLAYER_762MM, flBaseDamage, G3SG1_RANGE_MODIFER, m_pPlayer->pev, true, m_pPlayer->random_seed);
+	vecDir = m_hPlayer->FireBullets3(vecSrc, vecAiming, (1 - m_flAccuracy) * flSpread, 8192, 3, BULLET_PLAYER_762MM, flBaseDamage, G3SG1_RANGE_MODIFER, m_hPlayer->pev, true, m_hPlayer->random_seed);
 
 #ifdef CLIENT_WEAPONS
 	flag = FEV_NOTHOST;
@@ -173,35 +173,35 @@ void CG3SG1::G3SG1Fire(float flSpread, float flCycleTime, BOOL fUseAutoAim)
 	flag = 0;
 #endif
 
-	PLAYBACK_EVENT_FULL(flag, m_pPlayer->edict(), m_usFireG3SG1, 0, (float *)&g_vecZero, (float *)&g_vecZero, vecDir.x, vecDir.y,
-		int(m_pPlayer->pev->punchangle.x * 100), int(m_pPlayer->pev->punchangle.x * 100), FALSE, FALSE);
+	PLAYBACK_EVENT_FULL(flag, m_hPlayer->edict(), m_usFireG3SG1, 0, (float *)&g_vecZero, (float *)&g_vecZero, vecDir.x, vecDir.y,
+		int(m_hPlayer->pev->punchangle.x * 100), int(m_hPlayer->pev->punchangle.x * 100), FALSE, FALSE);
 
 	m_flNextPrimaryAttack = m_flNextSecondaryAttack = GetNextAttackDelay(flCycleTime);
 
-	if (!m_iClip && m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType] <= 0)
+	if (!m_iClip && m_hPlayer->m_rgAmmo[m_iPrimaryAmmoType] <= 0)
 	{
-		m_pPlayer->SetSuitUpdate("!HEV_AMO0", SUIT_SENTENCE, SUIT_REPEAT_OK);
+		m_hPlayer->SetSuitUpdate("!HEV_AMO0", SUIT_SENTENCE, SUIT_REPEAT_OK);
 	}
 
 	m_flTimeWeaponIdle = UTIL_WeaponTimeBase() + 1.8f;
 
-	m_pPlayer->pev->punchangle.x -= UTIL_SharedRandomFloat(m_pPlayer->random_seed + 4, 0.75, 1.75) + m_pPlayer->pev->punchangle.x * 0.25f;
-	m_pPlayer->pev->punchangle.y += UTIL_SharedRandomFloat(m_pPlayer->random_seed + 5, -0.75, 0.75);
+	m_hPlayer->pev->punchangle.x -= UTIL_SharedRandomFloat(m_hPlayer->random_seed + 4, 0.75, 1.75) + m_hPlayer->pev->punchangle.x * 0.25f;
+	m_hPlayer->pev->punchangle.y += UTIL_SharedRandomFloat(m_hPlayer->random_seed + 5, -0.75, 0.75);
 }
 
 void CG3SG1::Reload()
 {
-	if (m_pPlayer->ammo_762nato <= 0)
+	if (m_hPlayer->ammo_762nato <= 0)
 		return;
 
 	if (DefaultReload(iMaxClip(), G3SG1_RELOAD, G3SG1_RELOAD_TIME))
 	{
 		m_flAccuracy = 0.2f;
-		m_pPlayer->SetAnimation(PLAYER_RELOAD);
+		m_hPlayer->SetAnimation(PLAYER_RELOAD);
 
-		if (m_pPlayer->pev->fov != DEFAULT_FOV)
+		if (m_hPlayer->pev->fov != DEFAULT_FOV)
 		{
-			m_pPlayer->m_iFOV = m_pPlayer->pev->fov = 15;
+			m_hPlayer->m_iFOV = m_hPlayer->pev->fov = 15;
 			SecondaryAttack();
 		}
 
@@ -216,7 +216,7 @@ void CG3SG1::Reload()
 void CG3SG1::WeaponIdle()
 {
 	ResetEmptySound();
-	m_pPlayer->GetAutoaimVector(AUTOAIM_10DEGREES);
+	m_hPlayer->GetAutoaimVector(AUTOAIM_10DEGREES);
 
 	if (m_flTimeWeaponIdle <= UTIL_WeaponTimeBase())
 	{
@@ -230,5 +230,5 @@ void CG3SG1::WeaponIdle()
 
 float CG3SG1::GetMaxSpeed()
 {
-	return (m_pPlayer->m_iFOV == DEFAULT_FOV) ? G3SG1_MAX_SPEED : G3SG1_MAX_SPEED_ZOOM;
+	return (m_hPlayer->m_iFOV == DEFAULT_FOV) ? G3SG1_MAX_SPEED : G3SG1_MAX_SPEED_ZOOM;
 }

--- a/regamedll/dlls/wpn_shared/wpn_galil.cpp
+++ b/regamedll/dlls/wpn_shared/wpn_galil.cpp
@@ -70,11 +70,11 @@ void CGalil::SecondaryAttack()
 
 void CGalil::PrimaryAttack()
 {
-	if (!(m_pPlayer->pev->flags & FL_ONGROUND))
+	if (!(m_hPlayer->pev->flags & FL_ONGROUND))
 	{
 		GalilFire(0.04 + (0.3 * m_flAccuracy), 0.0875, FALSE);
 	}
-	else if (m_pPlayer->pev->velocity.Length2D() > 140)
+	else if (m_hPlayer->pev->velocity.Length2D() > 140)
 	{
 		GalilFire(0.04 + (0.07 * m_flAccuracy), 0.0875, FALSE);
 	}
@@ -107,19 +107,19 @@ void CGalil::GalilFire(float flSpread, float flCycleTime, BOOL fUseAutoAim)
 
 		if (TheBots)
 		{
-			TheBots->OnEvent(EVENT_WEAPON_FIRED_ON_EMPTY, m_pPlayer);
+			TheBots->OnEvent(EVENT_WEAPON_FIRED_ON_EMPTY, m_hPlayer);
 		}
 
 		return;
 	}
 
 	m_iClip--;
-	m_pPlayer->pev->effects |= EF_MUZZLEFLASH;
-	m_pPlayer->SetAnimation(PLAYER_ATTACK1);
+	m_hPlayer->pev->effects |= EF_MUZZLEFLASH;
+	m_hPlayer->SetAnimation(PLAYER_ATTACK1);
 
-	UTIL_MakeVectors(m_pPlayer->pev->v_angle + m_pPlayer->pev->punchangle);
+	UTIL_MakeVectors(m_hPlayer->pev->v_angle + m_hPlayer->pev->punchangle);
 
-	vecSrc = m_pPlayer->GetGunPosition();
+	vecSrc = m_hPlayer->GetGunPosition();
 	vecAiming = gpGlobals->v_forward;
 
 #ifdef REGAMEDLL_API
@@ -127,8 +127,8 @@ void CGalil::GalilFire(float flSpread, float flCycleTime, BOOL fUseAutoAim)
 #else
 	float flBaseDamage = GALIL_DAMAGE;
 #endif
-	vecDir = m_pPlayer->FireBullets3(vecSrc, vecAiming, flSpread, 8192, 2, BULLET_PLAYER_556MM,
-		flBaseDamage, GALIL_RANGE_MODIFER, m_pPlayer->pev, false, m_pPlayer->random_seed);
+	vecDir = m_hPlayer->FireBullets3(vecSrc, vecAiming, flSpread, 8192, 2, BULLET_PLAYER_556MM,
+		flBaseDamage, GALIL_RANGE_MODIFER, m_hPlayer->pev, false, m_hPlayer->random_seed);
 
 #ifdef CLIENT_WEAPONS
 	flag = FEV_NOTHOST;
@@ -138,33 +138,33 @@ void CGalil::GalilFire(float flSpread, float flCycleTime, BOOL fUseAutoAim)
 
 #ifdef REGAMEDLL_ADD
 	// HACKHACK: client-side weapon prediction fix
-	if (!(iFlags() & ITEM_FLAG_NOFIREUNDERWATER) && m_pPlayer->pev->waterlevel == 3)
+	if (!(iFlags() & ITEM_FLAG_NOFIREUNDERWATER) && m_hPlayer->pev->waterlevel == 3)
 		flag = 0;
 #endif
-	PLAYBACK_EVENT_FULL(flag, m_pPlayer->edict(), m_usFireGalil, 0, (float *)&g_vecZero, (float *)&g_vecZero, vecDir.x, vecDir.y,
-		int(m_pPlayer->pev->punchangle.x * 10000000), int(m_pPlayer->pev->punchangle.y * 10000000), FALSE, FALSE);
+	PLAYBACK_EVENT_FULL(flag, m_hPlayer->edict(), m_usFireGalil, 0, (float *)&g_vecZero, (float *)&g_vecZero, vecDir.x, vecDir.y,
+		int(m_hPlayer->pev->punchangle.x * 10000000), int(m_hPlayer->pev->punchangle.y * 10000000), FALSE, FALSE);
 
-	m_pPlayer->m_iWeaponVolume = NORMAL_GUN_VOLUME;
-	m_pPlayer->m_iWeaponFlash = BRIGHT_GUN_FLASH;
+	m_hPlayer->m_iWeaponVolume = NORMAL_GUN_VOLUME;
+	m_hPlayer->m_iWeaponFlash = BRIGHT_GUN_FLASH;
 
 	m_flNextPrimaryAttack = m_flNextSecondaryAttack = GetNextAttackDelay(flCycleTime);
 
-	if (!m_iClip && m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType] <= 0)
+	if (!m_iClip && m_hPlayer->m_rgAmmo[m_iPrimaryAmmoType] <= 0)
 	{
-		m_pPlayer->SetSuitUpdate("!HEV_AMO0", SUIT_SENTENCE, SUIT_REPEAT_OK);
+		m_hPlayer->SetSuitUpdate("!HEV_AMO0", SUIT_SENTENCE, SUIT_REPEAT_OK);
 	}
 
 	m_flTimeWeaponIdle = UTIL_WeaponTimeBase() + 1.28f;
 
-	if (m_pPlayer->pev->velocity.Length2D() > 0)
+	if (m_hPlayer->pev->velocity.Length2D() > 0)
 	{
 		KickBack(1.0, 0.45, 0.28, 0.045, 3.75, 3.0, 7);
 	}
-	else if (!(m_pPlayer->pev->flags & FL_ONGROUND))
+	else if (!(m_hPlayer->pev->flags & FL_ONGROUND))
 	{
 		KickBack(1.2, 0.5, 0.23, 0.15, 5.5, 3.5, 6);
 	}
-	else if (m_pPlayer->pev->flags & FL_DUCKING)
+	else if (m_hPlayer->pev->flags & FL_DUCKING)
 	{
 		KickBack(0.6, 0.3, 0.2, 0.0125, 3.25, 2.0, 7);
 	}
@@ -178,13 +178,13 @@ void CGalil::Reload()
 {
 #ifdef REGAMEDLL_FIXES
 	// to prevent reload if not enough ammo
-	if (m_pPlayer->ammo_556nato <= 0)
+	if (m_hPlayer->ammo_556nato <= 0)
 		return;
 #endif
 
 	if (DefaultReload(iMaxClip(), GALIL_RELOAD, GALIL_RELOAD_TIME))
 	{
-		m_pPlayer->SetAnimation(PLAYER_RELOAD);
+		m_hPlayer->SetAnimation(PLAYER_RELOAD);
 
 		m_flAccuracy = 0.2f;
 		m_iShotsFired = 0;
@@ -195,7 +195,7 @@ void CGalil::Reload()
 void CGalil::WeaponIdle()
 {
 	ResetEmptySound();
-	m_pPlayer->GetAutoaimVector(AUTOAIM_10DEGREES);
+	m_hPlayer->GetAutoaimVector(AUTOAIM_10DEGREES);
 
 	if (m_flTimeWeaponIdle <= UTIL_WeaponTimeBase())
 	{

--- a/regamedll/dlls/wpn_shared/wpn_glock18.cpp
+++ b/regamedll/dlls/wpn_shared/wpn_glock18.cpp
@@ -75,9 +75,9 @@ BOOL CGLOCK18::Deploy()
 	m_flAccuracy = 0.9f;
 	m_fMaxSpeed = GLOCK18_MAX_SPEED;
 
-	m_pPlayer->m_bShieldDrawn = false;
+	m_hPlayer->m_bShieldDrawn = false;
 
-	if (m_pPlayer->HasShield())
+	if (m_hPlayer->HasShield())
 	{
 		m_iWeaponState &= ~WPNSTATE_GLOCK18_BURST_MODE;
 		return DefaultDeploy("models/shield/v_shield_glock18.mdl", "models/shield/p_shield_glock18.mdl", GLOCK18_SHIELD_DRAW, "shieldgun", UseDecrement() != FALSE);
@@ -99,12 +99,12 @@ void CGLOCK18::SecondaryAttack()
 
 	if (m_iWeaponState & WPNSTATE_GLOCK18_BURST_MODE)
 	{
-		ClientPrint(m_pPlayer->pev, HUD_PRINTCENTER, "#Switch_To_SemiAuto");
+		ClientPrint(m_hPlayer->pev, HUD_PRINTCENTER, "#Switch_To_SemiAuto");
 		m_iWeaponState &= ~WPNSTATE_GLOCK18_BURST_MODE;
 	}
 	else
 	{
-		ClientPrint(m_pPlayer->pev, HUD_PRINTCENTER, "#Switch_To_BurstFire");
+		ClientPrint(m_hPlayer->pev, HUD_PRINTCENTER, "#Switch_To_BurstFire");
 		m_iWeaponState |= WPNSTATE_GLOCK18_BURST_MODE;
 	}
 
@@ -115,15 +115,15 @@ void CGLOCK18::PrimaryAttack()
 {
 	if (m_iWeaponState & WPNSTATE_GLOCK18_BURST_MODE)
 	{
-		if (!(m_pPlayer->pev->flags & FL_ONGROUND))
+		if (!(m_hPlayer->pev->flags & FL_ONGROUND))
 		{
 			GLOCK18Fire(1.2 * (1 - m_flAccuracy), 0.5, TRUE);
 		}
-		else if (m_pPlayer->pev->velocity.Length2D() > 0)
+		else if (m_hPlayer->pev->velocity.Length2D() > 0)
 		{
 			GLOCK18Fire(0.185 * (1 - m_flAccuracy), 0.5, TRUE);
 		}
-		else if (m_pPlayer->pev->flags & FL_DUCKING)
+		else if (m_hPlayer->pev->flags & FL_DUCKING)
 		{
 			GLOCK18Fire(0.095 * (1 - m_flAccuracy), 0.5, TRUE);
 		}
@@ -134,15 +134,15 @@ void CGLOCK18::PrimaryAttack()
 	}
 	else
 	{
-		if (!(m_pPlayer->pev->flags & FL_ONGROUND))
+		if (!(m_hPlayer->pev->flags & FL_ONGROUND))
 		{
 			GLOCK18Fire(1.0 * (1 - m_flAccuracy), 0.2, FALSE);
 		}
-		else if (m_pPlayer->pev->velocity.Length2D() > 0)
+		else if (m_hPlayer->pev->velocity.Length2D() > 0)
 		{
 			GLOCK18Fire(0.165 * (1 - m_flAccuracy), 0.2, FALSE);
 		}
-		else if (m_pPlayer->pev->flags & FL_DUCKING)
+		else if (m_hPlayer->pev->flags & FL_DUCKING)
 		{
 			GLOCK18Fire(0.075 * (1 - m_flAccuracy), 0.2, FALSE);
 		}
@@ -199,25 +199,25 @@ void CGLOCK18::GLOCK18Fire(float flSpread, float flCycleTime, BOOL bFireBurst)
 
 		if (TheBots)
 		{
-			TheBots->OnEvent(EVENT_WEAPON_FIRED_ON_EMPTY, m_pPlayer);
+			TheBots->OnEvent(EVENT_WEAPON_FIRED_ON_EMPTY, m_hPlayer);
 		}
 
 		return;
 	}
 
 	m_iClip--;
-	m_pPlayer->pev->effects |= EF_MUZZLEFLASH;
+	m_hPlayer->pev->effects |= EF_MUZZLEFLASH;
 
 	// player "shoot" animation
-	m_pPlayer->SetAnimation(PLAYER_ATTACK1);
+	m_hPlayer->SetAnimation(PLAYER_ATTACK1);
 
-	UTIL_MakeVectors(m_pPlayer->pev->v_angle + m_pPlayer->pev->punchangle);
+	UTIL_MakeVectors(m_hPlayer->pev->v_angle + m_hPlayer->pev->punchangle);
 
 	// non-silenced
-	m_pPlayer->m_iWeaponVolume = NORMAL_GUN_VOLUME;
-	m_pPlayer->m_iWeaponFlash = NORMAL_GUN_FLASH;
+	m_hPlayer->m_iWeaponVolume = NORMAL_GUN_VOLUME;
+	m_hPlayer->m_iWeaponFlash = NORMAL_GUN_FLASH;
 
-	vecSrc = m_pPlayer->GetGunPosition();
+	vecSrc = m_hPlayer->GetGunPosition();
 	vecAiming = gpGlobals->v_forward;
 
 #ifdef REGAMEDLL_API
@@ -225,7 +225,7 @@ void CGLOCK18::GLOCK18Fire(float flSpread, float flCycleTime, BOOL bFireBurst)
 #else
 	float flBaseDamage = GLOCK18_DAMAGE;
 #endif
-	vecDir = m_pPlayer->FireBullets3(vecSrc, vecAiming, flSpread, 8192, 1, BULLET_PLAYER_9MM, flBaseDamage, GLOCK18_RANGE_MODIFER, m_pPlayer->pev, true, m_pPlayer->random_seed);
+	vecDir = m_hPlayer->FireBullets3(vecSrc, vecAiming, flSpread, 8192, 1, BULLET_PLAYER_9MM, flBaseDamage, GLOCK18_RANGE_MODIFER, m_hPlayer->pev, true, m_hPlayer->random_seed);
 
 #ifdef CLIENT_WEAPONS
 	flag = FEV_NOTHOST;
@@ -233,15 +233,15 @@ void CGLOCK18::GLOCK18Fire(float flSpread, float flCycleTime, BOOL bFireBurst)
 	flag = 0;
 #endif
 
-	PLAYBACK_EVENT_FULL(flag, m_pPlayer->edict(), m_usFireGlock18, 0, (float *)&g_vecZero, (float *)&g_vecZero, vecDir.x, vecDir.y,
-		int(m_pPlayer->pev->punchangle.x * 100), int(m_pPlayer->pev->punchangle.y * 100), m_iClip == 0, FALSE);
+	PLAYBACK_EVENT_FULL(flag, m_hPlayer->edict(), m_usFireGlock18, 0, (float *)&g_vecZero, (float *)&g_vecZero, vecDir.x, vecDir.y,
+		int(m_hPlayer->pev->punchangle.x * 100), int(m_hPlayer->pev->punchangle.y * 100), m_iClip == 0, FALSE);
 
 	m_flNextPrimaryAttack = m_flNextSecondaryAttack = GetNextAttackDelay(flCycleTime);
 
-	if (!m_iClip && m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType] <= 0)
+	if (!m_iClip && m_hPlayer->m_rgAmmo[m_iPrimaryAmmoType] <= 0)
 	{
 		// HEV suit - indicate out of ammo condition
-		m_pPlayer->SetSuitUpdate("!HEV_AMO0", SUIT_SENTENCE, SUIT_REPEAT_OK);
+		m_hPlayer->SetSuitUpdate("!HEV_AMO0", SUIT_SENTENCE, SUIT_REPEAT_OK);
 	}
 
 	m_flTimeWeaponIdle = UTIL_WeaponTimeBase() + 2.5f;
@@ -259,10 +259,10 @@ void CGLOCK18::GLOCK18Fire(float flSpread, float flCycleTime, BOOL bFireBurst)
 void CGLOCK18::Reload()
 {
 	int iResult;
-	if (m_pPlayer->ammo_9mm <= 0)
+	if (m_hPlayer->ammo_9mm <= 0)
 		return;
 
-	if (m_pPlayer->HasShield())
+	if (m_hPlayer->HasShield())
 		iResult = GLOCK18_SHIELD_RELOAD;
 	else if (RANDOM_LONG(0, 1))
 		iResult = GLOCK18_RELOAD;
@@ -271,7 +271,7 @@ void CGLOCK18::Reload()
 
 	if (DefaultReload(iMaxClip(), iResult, GLOCK18_RELOAD_TIME))
 	{
-		m_pPlayer->SetAnimation(PLAYER_RELOAD);
+		m_hPlayer->SetAnimation(PLAYER_RELOAD);
 		m_flAccuracy = 0.9;
 	}
 }
@@ -282,14 +282,14 @@ void CGLOCK18::WeaponIdle()
 	float flRand;
 
 	ResetEmptySound();
-	m_pPlayer->GetAutoaimVector(AUTOAIM_10DEGREES);
+	m_hPlayer->GetAutoaimVector(AUTOAIM_10DEGREES);
 
 	if (m_flTimeWeaponIdle > UTIL_WeaponTimeBase())
 	{
 		return;
 	}
 
-	if (m_pPlayer->HasShield())
+	if (m_hPlayer->HasShield())
 	{
 		m_flTimeWeaponIdle = UTIL_WeaponTimeBase() + 20.0f;
 

--- a/regamedll/dlls/wpn_shared/wpn_hegrenade.cpp
+++ b/regamedll/dlls/wpn_shared/wpn_hegrenade.cpp
@@ -63,9 +63,9 @@ BOOL CHEGrenade::Deploy()
 	m_fMaxSpeed = HEGRENADE_MAX_SPEED;
 	m_iWeaponState &= ~WPNSTATE_SHIELD_DRAWN;
 
-	m_pPlayer->m_bShieldDrawn = false;
+	m_hPlayer->m_bShieldDrawn = false;
 
-	if (m_pPlayer->HasShield())
+	if (m_hPlayer->HasShield())
 		return DefaultDeploy("models/shield/v_shield_hegrenade.mdl", "models/shield/p_shield_hegrenade.mdl", HEGRENADE_DRAW, "shieldgren", UseDecrement() != FALSE);
 	else
 		return DefaultDeploy("models/v_hegrenade.mdl", "models/p_hegrenade.mdl", HEGRENADE_DRAW, "grenade", UseDecrement() != FALSE);
@@ -73,13 +73,13 @@ BOOL CHEGrenade::Deploy()
 
 void CHEGrenade::Holster(int skiplocal)
 {
-	m_pPlayer->m_flNextAttack = UTIL_WeaponTimeBase() + 0.5f;
+	m_hPlayer->m_flNextAttack = UTIL_WeaponTimeBase() + 0.5f;
 
-	if (!m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType])
+	if (!m_hPlayer->m_rgAmmo[m_iPrimaryAmmoType])
 	{
 #ifndef REGAMEDLL_FIXES
 		// Moved to DestroyItem()
-		m_pPlayer->pev->weapons &= ~(1 << WEAPON_HEGRENADE);
+		m_hPlayer->pev->weapons &= ~(1 << WEAPON_HEGRENADE);
 #endif
 
 		DestroyItem();
@@ -96,7 +96,7 @@ void CHEGrenade::PrimaryAttack()
 		return;
 	}
 
-	if (!m_flStartThrow && m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType] > 0)
+	if (!m_flStartThrow && m_hPlayer->m_rgAmmo[m_iPrimaryAmmoType] > 0)
 	{
 		m_flReleaseThrow = 0;
 		m_flStartThrow = gpGlobals->time;
@@ -108,7 +108,7 @@ void CHEGrenade::PrimaryAttack()
 
 bool CHEGrenade::ShieldSecondaryFire(int iUpAnim, int iDownAnim)
 {
-	if (!m_pPlayer->HasShield() || m_flStartThrow > 0)
+	if (!m_hPlayer->HasShield() || m_flStartThrow > 0)
 	{
 		return false;
 	}
@@ -117,23 +117,23 @@ bool CHEGrenade::ShieldSecondaryFire(int iUpAnim, int iDownAnim)
 	{
 		m_iWeaponState &= ~WPNSTATE_SHIELD_DRAWN;
 		SendWeaponAnim(iDownAnim, UseDecrement() != FALSE);
-		Q_strcpy(m_pPlayer->m_szAnimExtention, "shieldgren");
+		Q_strcpy(m_hPlayer->m_szAnimExtention, "shieldgren");
 
 		m_fMaxSpeed = HEGRENADE_MAX_SPEED;
-		m_pPlayer->m_bShieldDrawn = false;
+		m_hPlayer->m_bShieldDrawn = false;
 	}
 	else
 	{
 		m_iWeaponState |= WPNSTATE_SHIELD_DRAWN;
 		SendWeaponAnim(iUpAnim, UseDecrement() != FALSE);
-		Q_strcpy(m_pPlayer->m_szAnimExtention, "shielded");
+		Q_strcpy(m_hPlayer->m_szAnimExtention, "shielded");
 
 		m_fMaxSpeed = HEGRENADE_MAX_SPEED_SHIELD;
-		m_pPlayer->m_bShieldDrawn = true;
+		m_hPlayer->m_bShieldDrawn = true;
 	}
 
-	m_pPlayer->UpdateShieldCrosshair((m_iWeaponState & WPNSTATE_SHIELD_DRAWN) != WPNSTATE_SHIELD_DRAWN);
-	m_pPlayer->ResetMaxSpeed();
+	m_hPlayer->UpdateShieldCrosshair((m_iWeaponState & WPNSTATE_SHIELD_DRAWN) != WPNSTATE_SHIELD_DRAWN);
+	m_hPlayer->ResetMaxSpeed();
 
 	m_flNextSecondaryAttack = UTIL_WeaponTimeBase() + 0.4f;
 	m_flNextPrimaryAttack = GetNextAttackDelay(0.4);
@@ -149,23 +149,23 @@ void CHEGrenade::SecondaryAttack()
 
 void CHEGrenade::SetPlayerShieldAnim()
 {
-	if (!m_pPlayer->HasShield())
+	if (!m_hPlayer->HasShield())
 		return;
 
 	if (m_iWeaponState & WPNSTATE_SHIELD_DRAWN)
-		Q_strcpy(m_pPlayer->m_szAnimExtention, "shield");
+		Q_strcpy(m_hPlayer->m_szAnimExtention, "shield");
 	else
-		Q_strcpy(m_pPlayer->m_szAnimExtention, "shieldgren");
+		Q_strcpy(m_hPlayer->m_szAnimExtention, "shieldgren");
 }
 
 void CHEGrenade::ResetPlayerShieldAnim()
 {
-	if (!m_pPlayer->HasShield())
+	if (!m_hPlayer->HasShield())
 		return;
 
 	if (m_iWeaponState & WPNSTATE_SHIELD_DRAWN)
 	{
-		Q_strcpy(m_pPlayer->m_szAnimExtention, "shieldgren");
+		Q_strcpy(m_hPlayer->m_szAnimExtention, "shieldgren");
 	}
 }
 
@@ -179,9 +179,9 @@ void CHEGrenade::WeaponIdle()
 
 	if (m_flStartThrow)
 	{
-		m_pPlayer->Radio("%!MRAD_FIREINHOLE", "#Fire_in_the_hole");
+		m_hPlayer->Radio("%!MRAD_FIREINHOLE", "#Fire_in_the_hole");
 
-		Vector angThrow = m_pPlayer->pev->v_angle + m_pPlayer->pev->punchangle;
+		Vector angThrow = m_hPlayer->pev->v_angle + m_hPlayer->pev->punchangle;
 
 		if (angThrow.x < 0)
 			angThrow.x = -10 + angThrow.x * ((90 - 10) / 90.0);
@@ -195,22 +195,22 @@ void CHEGrenade::WeaponIdle()
 
 		UTIL_MakeVectors(angThrow);
 
-		Vector vecSrc = m_pPlayer->pev->origin + m_pPlayer->pev->view_ofs + gpGlobals->v_forward * 16;
-		Vector vecThrow = gpGlobals->v_forward * flVel + m_pPlayer->pev->velocity;
+		Vector vecSrc = m_hPlayer->pev->origin + m_hPlayer->pev->view_ofs + gpGlobals->v_forward * 16;
+		Vector vecThrow = gpGlobals->v_forward * flVel + m_hPlayer->pev->velocity;
 
-		m_pPlayer->ThrowGrenade(this, vecSrc, vecThrow, 1.5, m_usCreateExplosion);
+		m_hPlayer->ThrowGrenade(this, vecSrc, vecThrow, 1.5, m_usCreateExplosion);
 
 		SendWeaponAnim(HEGRENADE_THROW, UseDecrement() != FALSE);
 		SetPlayerShieldAnim();
 
 		// player "shoot" animation
-		m_pPlayer->SetAnimation(PLAYER_ATTACK1);
+		m_hPlayer->SetAnimation(PLAYER_ATTACK1);
 
 		m_flStartThrow = 0;
 		m_flNextPrimaryAttack = GetNextAttackDelay(0.5);
 		m_flTimeWeaponIdle = UTIL_WeaponTimeBase() + 0.75f;
 
-		if (--m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType] <= 0)
+		if (--m_hPlayer->m_rgAmmo[m_iPrimaryAmmoType] <= 0)
 		{
 			// just threw last grenade
 			// set attack times in the future, and weapon idle in the future so we can see the whole throw
@@ -226,7 +226,7 @@ void CHEGrenade::WeaponIdle()
 		// we've finished the throw, restart.
 		m_flStartThrow = 0;
 
-		if (m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType])
+		if (m_hPlayer->m_rgAmmo[m_iPrimaryAmmoType])
 		{
 			SendWeaponAnim(HEGRENADE_DRAW, UseDecrement() != FALSE);
 		}
@@ -239,9 +239,9 @@ void CHEGrenade::WeaponIdle()
 		m_flTimeWeaponIdle = UTIL_WeaponTimeBase() + RANDOM_FLOAT(10, 15);
 		m_flReleaseThrow = -1.0f;
 	}
-	else if (m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType])
+	else if (m_hPlayer->m_rgAmmo[m_iPrimaryAmmoType])
 	{
-		if (m_pPlayer->HasShield())
+		if (m_hPlayer->HasShield())
 		{
 			m_flTimeWeaponIdle = UTIL_WeaponTimeBase() + 20.0f;
 
@@ -264,5 +264,5 @@ LINK_HOOK_CLASS_CHAIN3(BOOL, CBasePlayerWeapon, CHEGrenade, CanDeploy)
 
 BOOL EXT_FUNC CHEGrenade::__API_HOOK(CanDeploy)()
 {
-	return m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType] != 0;
+	return m_hPlayer->m_rgAmmo[m_iPrimaryAmmoType] != 0;
 }

--- a/regamedll/dlls/wpn_shared/wpn_knife.cpp
+++ b/regamedll/dlls/wpn_shared/wpn_knife.cpp
@@ -71,15 +71,15 @@ int CKnife::GetItemInfo(ItemInfo *p)
 
 BOOL CKnife::Deploy()
 {
-	EMIT_SOUND(m_pPlayer->edict(), CHAN_ITEM, "weapons/knife_deploy1.wav", 0.3, 2.4);
+	EMIT_SOUND(m_hPlayer->edict(), CHAN_ITEM, "weapons/knife_deploy1.wav", 0.3, 2.4);
 
 	m_iSwing = 0;
 	m_fMaxSpeed = KNIFE_MAX_SPEED;
 
 	m_iWeaponState &= ~WPNSTATE_SHIELD_DRAWN;
-	m_pPlayer->m_bShieldDrawn = false;
+	m_hPlayer->m_bShieldDrawn = false;
 
-	if (m_pPlayer->HasShield())
+	if (m_hPlayer->HasShield())
 	{
 		return DefaultDeploy("models/shield/v_shield_knife.mdl", "models/shield/p_shield_knife.mdl", KNIFE_SHIELD_DRAW, "shieldknife", UseDecrement() != FALSE);
 	}
@@ -89,7 +89,7 @@ BOOL CKnife::Deploy()
 
 void CKnife::Holster(int skiplocal)
 {
-	m_pPlayer->m_flNextAttack = UTIL_WeaponTimeBase() + 0.5f;
+	m_hPlayer->m_flNextAttack = UTIL_WeaponTimeBase() + 0.5f;
 }
 
 NOXREF void CKnife::WeaponAnimation(int iAnimation)
@@ -102,7 +102,7 @@ NOXREF void CKnife::WeaponAnimation(int iAnimation)
 	flag = 0;
 #endif
 
-	PLAYBACK_EVENT_FULL(flag, m_pPlayer->edict(), m_usKnife,
+	PLAYBACK_EVENT_FULL(flag, m_hPlayer->edict(), m_usKnife,
 		0.0, (float *)&g_vecZero, (float *)&g_vecZero,
 		0.0,
 		0.0,
@@ -163,33 +163,33 @@ void CKnife::PrimaryAttack()
 
 void CKnife::SetPlayerShieldAnim()
 {
-	if (!m_pPlayer->HasShield())
+	if (!m_hPlayer->HasShield())
 		return;
 
 	if (m_iWeaponState & WPNSTATE_SHIELD_DRAWN)
 	{
-		Q_strcpy(m_pPlayer->m_szAnimExtention, "shield");
+		Q_strcpy(m_hPlayer->m_szAnimExtention, "shield");
 	}
 	else
 	{
-		Q_strcpy(m_pPlayer->m_szAnimExtention, "shieldknife");
+		Q_strcpy(m_hPlayer->m_szAnimExtention, "shieldknife");
 	}
 }
 
 void CKnife::ResetPlayerShieldAnim()
 {
-	if (!m_pPlayer->HasShield())
+	if (!m_hPlayer->HasShield())
 		return;
 
 	if (m_iWeaponState & WPNSTATE_SHIELD_DRAWN)
 	{
-		Q_strcpy(m_pPlayer->m_szAnimExtention, "shieldknife");
+		Q_strcpy(m_hPlayer->m_szAnimExtention, "shieldknife");
 	}
 }
 
 bool CKnife::ShieldSecondaryFire(int iUpAnim, int iDownAnim)
 {
-	if (!m_pPlayer->HasShield())
+	if (!m_hPlayer->HasShield())
 	{
 		return false;
 	}
@@ -200,24 +200,24 @@ bool CKnife::ShieldSecondaryFire(int iUpAnim, int iDownAnim)
 
 		SendWeaponAnim(iDownAnim, UseDecrement() != FALSE);
 
-		Q_strcpy(m_pPlayer->m_szAnimExtention, "shieldknife");
+		Q_strcpy(m_hPlayer->m_szAnimExtention, "shieldknife");
 
 		m_fMaxSpeed = KNIFE_MAX_SPEED;
-		m_pPlayer->m_bShieldDrawn = false;
+		m_hPlayer->m_bShieldDrawn = false;
 	}
 	else
 	{
 		m_iWeaponState |= WPNSTATE_SHIELD_DRAWN;
 		SendWeaponAnim(iUpAnim, UseDecrement() != FALSE);
 
-		Q_strcpy(m_pPlayer->m_szAnimExtention, "shielded");
+		Q_strcpy(m_hPlayer->m_szAnimExtention, "shielded");
 
 		m_fMaxSpeed = KNIFE_MAX_SPEED_SHIELD;
-		m_pPlayer->m_bShieldDrawn = true;
+		m_hPlayer->m_bShieldDrawn = true;
 	}
 
-	m_pPlayer->UpdateShieldCrosshair((m_iWeaponState & WPNSTATE_SHIELD_DRAWN) != WPNSTATE_SHIELD_DRAWN);
-	m_pPlayer->ResetMaxSpeed();
+	m_hPlayer->UpdateShieldCrosshair((m_iWeaponState & WPNSTATE_SHIELD_DRAWN) != WPNSTATE_SHIELD_DRAWN);
+	m_hPlayer->ResetMaxSpeed();
 
 	m_flNextPrimaryAttack = GetNextAttackDelay(0.4);
 	m_flNextSecondaryAttack = UTIL_WeaponTimeBase() + 0.4f;
@@ -237,7 +237,7 @@ void CKnife::SecondaryAttack()
 
 void CKnife::Smack()
 {
-	DecalGunshot(&m_trHit, BULLET_PLAYER_CROWBAR, false, m_pPlayer->pev, false);
+	DecalGunshot(&m_trHit, BULLET_PLAYER_CROWBAR, false, m_hPlayer->pev, false);
 }
 
 void CKnife::SwingAgain()
@@ -248,12 +248,12 @@ void CKnife::SwingAgain()
 void CKnife::WeaponIdle()
 {
 	ResetEmptySound();
-	m_pPlayer->GetAutoaimVector(AUTOAIM_10DEGREES);
+	m_hPlayer->GetAutoaimVector(AUTOAIM_10DEGREES);
 
 	if (m_flTimeWeaponIdle > UTIL_WeaponTimeBase())
 		return;
 
-	if (m_pPlayer->m_bShieldDrawn)
+	if (m_hPlayer->m_bShieldDrawn)
 		return;
 
 	m_flTimeWeaponIdle = UTIL_WeaponTimeBase() + 20.0f;
@@ -268,16 +268,16 @@ BOOL CKnife::Swing(BOOL fFirst)
 	TraceResult tr;
 	Vector vecSrc, vecEnd;
 
-	UTIL_MakeVectors(m_pPlayer->pev->v_angle);
+	UTIL_MakeVectors(m_hPlayer->pev->v_angle);
 
-	vecSrc = m_pPlayer->GetGunPosition();
+	vecSrc = m_hPlayer->GetGunPosition();
 	vecEnd = vecSrc + gpGlobals->v_forward * m_flSwingDistance;
 
-	UTIL_TraceLine(vecSrc, vecEnd, dont_ignore_monsters, m_pPlayer->edict(), &tr);
+	UTIL_TraceLine(vecSrc, vecEnd, dont_ignore_monsters, m_hPlayer->edict(), &tr);
 
 	if (tr.flFraction >= 1.0f)
 	{
-		UTIL_TraceHull(vecSrc, vecEnd, dont_ignore_monsters, head_hull, m_pPlayer->edict(), &tr);
+		UTIL_TraceHull(vecSrc, vecEnd, dont_ignore_monsters, head_hull, m_hPlayer->edict(), &tr);
 
 		if (tr.flFraction < 1.0f)
 		{
@@ -287,7 +287,7 @@ BOOL CKnife::Swing(BOOL fFirst)
 
 			if (!pHit || pHit->IsBSPModel())
 			{
-				FindHullIntersection(vecSrc, tr, VEC_DUCK_HULL_MIN, VEC_DUCK_HULL_MAX, m_pPlayer->edict());
+				FindHullIntersection(vecSrc, tr, VEC_DUCK_HULL_MIN, VEC_DUCK_HULL_MAX, m_hPlayer->edict());
 			}
 
 			// This is the point on the actual surface (the hull could have hit space)
@@ -299,7 +299,7 @@ BOOL CKnife::Swing(BOOL fFirst)
 	{
 		if (fFirst)
 		{
-			if (!m_pPlayer->HasShield())
+			if (!m_hPlayer->HasShield())
 			{
 				switch ((m_iSwing++) % 2)
 				{
@@ -323,12 +323,12 @@ BOOL CKnife::Swing(BOOL fFirst)
 
 			// play wiff or swish sound
 			if (RANDOM_LONG(0, 1))
-				EMIT_SOUND_DYN(m_pPlayer->edict(), CHAN_WEAPON, "weapons/knife_slash1.wav", VOL_NORM, ATTN_NORM, 0, 94);
+				EMIT_SOUND_DYN(m_hPlayer->edict(), CHAN_WEAPON, "weapons/knife_slash1.wav", VOL_NORM, ATTN_NORM, 0, 94);
 			else
-				EMIT_SOUND_DYN(m_pPlayer->edict(), CHAN_WEAPON, "weapons/knife_slash2.wav", VOL_NORM, ATTN_NORM, 0, 94);
+				EMIT_SOUND_DYN(m_hPlayer->edict(), CHAN_WEAPON, "weapons/knife_slash2.wav", VOL_NORM, ATTN_NORM, 0, 94);
 
 			// player "shoot" animation
-			m_pPlayer->SetAnimation(PLAYER_ATTACK1);
+			m_hPlayer->SetAnimation(PLAYER_ATTACK1);
 		}
 	}
 	else
@@ -336,7 +336,7 @@ BOOL CKnife::Swing(BOOL fFirst)
 		// hit
 		fDidHit = TRUE;
 
-		if (!m_pPlayer->HasShield())
+		if (!m_hPlayer->HasShield())
 		{
 			switch ((m_iSwing++) % 2)
 			{
@@ -365,15 +365,15 @@ BOOL CKnife::Swing(BOOL fFirst)
 		SetPlayerShieldAnim();
 
 		// player "shoot" animation
-		m_pPlayer->SetAnimation(PLAYER_ATTACK1);
+		m_hPlayer->SetAnimation(PLAYER_ATTACK1);
 		ClearMultiDamage();
 
 		if (m_flNextPrimaryAttack + 0.4f < UTIL_WeaponTimeBase())
-			pEntity->TraceAttack(m_pPlayer->pev, m_flSwingBaseDamage_Fast, gpGlobals->v_forward, &tr, (DMG_NEVERGIB | DMG_BULLET));
+			pEntity->TraceAttack(m_hPlayer->pev, m_flSwingBaseDamage_Fast, gpGlobals->v_forward, &tr, (DMG_NEVERGIB | DMG_BULLET));
 		else
-			pEntity->TraceAttack(m_pPlayer->pev, m_flSwingBaseDamage, gpGlobals->v_forward, &tr, (DMG_NEVERGIB | DMG_BULLET));
+			pEntity->TraceAttack(m_hPlayer->pev, m_flSwingBaseDamage, gpGlobals->v_forward, &tr, (DMG_NEVERGIB | DMG_BULLET));
 
-		ApplyMultiDamage(m_pPlayer->pev, m_pPlayer->pev);
+		ApplyMultiDamage(m_hPlayer->pev, m_hPlayer->pev);
 
 #ifndef REGAMEDLL_FIXES
 		if (pEntity)	// -V595
@@ -388,13 +388,13 @@ BOOL CKnife::Swing(BOOL fFirst)
 				// play thwack or smack sound
 				switch (RANDOM_LONG(0, 3))
 				{
-				case 0: EMIT_SOUND(m_pPlayer->edict(), CHAN_WEAPON, "weapons/knife_hit1.wav", VOL_NORM, ATTN_NORM); break;
-				case 1: EMIT_SOUND(m_pPlayer->edict(), CHAN_WEAPON, "weapons/knife_hit2.wav", VOL_NORM, ATTN_NORM); break;
-				case 2: EMIT_SOUND(m_pPlayer->edict(), CHAN_WEAPON, "weapons/knife_hit3.wav", VOL_NORM, ATTN_NORM); break;
-				case 3: EMIT_SOUND(m_pPlayer->edict(), CHAN_WEAPON, "weapons/knife_hit4.wav", VOL_NORM, ATTN_NORM); break;
+				case 0: EMIT_SOUND(m_hPlayer->edict(), CHAN_WEAPON, "weapons/knife_hit1.wav", VOL_NORM, ATTN_NORM); break;
+				case 1: EMIT_SOUND(m_hPlayer->edict(), CHAN_WEAPON, "weapons/knife_hit2.wav", VOL_NORM, ATTN_NORM); break;
+				case 2: EMIT_SOUND(m_hPlayer->edict(), CHAN_WEAPON, "weapons/knife_hit3.wav", VOL_NORM, ATTN_NORM); break;
+				case 3: EMIT_SOUND(m_hPlayer->edict(), CHAN_WEAPON, "weapons/knife_hit4.wav", VOL_NORM, ATTN_NORM); break;
 				}
 
-				m_pPlayer->m_iWeaponVolume = KNIFE_BODYHIT_VOLUME;
+				m_hPlayer->m_iWeaponVolume = KNIFE_BODYHIT_VOLUME;
 
 				if (!pEntity->IsAlive())
 					return TRUE;
@@ -426,14 +426,14 @@ BOOL CKnife::Swing(BOOL fFirst)
 			SetThink(&CKnife::Smack);
 
 			pev->nextthink = UTIL_WeaponTimeBase() + 0.2f;
-			m_pPlayer->m_iWeaponVolume = int(flVol * KNIFE_WALLHIT_VOLUME);
+			m_hPlayer->m_iWeaponVolume = int(flVol * KNIFE_WALLHIT_VOLUME);
 
 			ResetPlayerShieldAnim();
 		}
 		else
 		{
 			// also play knife strike
-			EMIT_SOUND_DYN(m_pPlayer->edict(), CHAN_ITEM, "weapons/knife_hitwall1.wav", VOL_NORM, ATTN_NORM, 0, RANDOM_LONG(0, 3) + 98);
+			EMIT_SOUND_DYN(m_hPlayer->edict(), CHAN_ITEM, "weapons/knife_hitwall1.wav", VOL_NORM, ATTN_NORM, 0, RANDOM_LONG(0, 3) + 98);
 		}
 	}
 
@@ -446,16 +446,16 @@ BOOL CKnife::Stab(BOOL fFirst)
 	TraceResult tr;
 	Vector vecSrc, vecEnd;
 
-	UTIL_MakeVectors(m_pPlayer->pev->v_angle);
+	UTIL_MakeVectors(m_hPlayer->pev->v_angle);
 
-	vecSrc = m_pPlayer->GetGunPosition();
+	vecSrc = m_hPlayer->GetGunPosition();
 	vecEnd = vecSrc + gpGlobals->v_forward * m_flStabDistance;
 
-	UTIL_TraceLine(vecSrc, vecEnd, dont_ignore_monsters, m_pPlayer->edict(), &tr);
+	UTIL_TraceLine(vecSrc, vecEnd, dont_ignore_monsters, m_hPlayer->edict(), &tr);
 
 	if (tr.flFraction >= 1.0f)
 	{
-		UTIL_TraceHull(vecSrc, vecEnd, dont_ignore_monsters, head_hull, m_pPlayer->edict(), &tr);
+		UTIL_TraceHull(vecSrc, vecEnd, dont_ignore_monsters, head_hull, m_hPlayer->edict(), &tr);
 
 		if (tr.flFraction < 1.0f)
 		{
@@ -465,7 +465,7 @@ BOOL CKnife::Stab(BOOL fFirst)
 
 			if (!pHit || pHit->IsBSPModel())
 			{
-				FindHullIntersection(vecSrc, tr, VEC_DUCK_HULL_MIN, VEC_DUCK_HULL_MAX, m_pPlayer->edict());
+				FindHullIntersection(vecSrc, tr, VEC_DUCK_HULL_MIN, VEC_DUCK_HULL_MAX, m_hPlayer->edict());
 			}
 
 			// This is the point on the actual surface (the hull could have hit space)
@@ -487,12 +487,12 @@ BOOL CKnife::Stab(BOOL fFirst)
 
 			// play wiff or swish sound
 			if (RANDOM_LONG(0, 1))
-				EMIT_SOUND_DYN(m_pPlayer->edict(), CHAN_WEAPON, "weapons/knife_slash1.wav", VOL_NORM, ATTN_NORM, 0, 94);
+				EMIT_SOUND_DYN(m_hPlayer->edict(), CHAN_WEAPON, "weapons/knife_slash1.wav", VOL_NORM, ATTN_NORM, 0, 94);
 			else
-				EMIT_SOUND_DYN(m_pPlayer->edict(), CHAN_WEAPON, "weapons/knife_slash2.wav", VOL_NORM, ATTN_NORM, 0, 94);
+				EMIT_SOUND_DYN(m_hPlayer->edict(), CHAN_WEAPON, "weapons/knife_slash2.wav", VOL_NORM, ATTN_NORM, 0, 94);
 
 			// player "shoot" animation
-			m_pPlayer->SetAnimation(PLAYER_ATTACK1);
+			m_hPlayer->SetAnimation(PLAYER_ATTACK1);
 		}
 	}
 	else
@@ -515,7 +515,7 @@ BOOL CKnife::Stab(BOOL fFirst)
 		CBaseEntity *pEntity = CBaseEntity::Instance(tr.pHit);
 
 		// player "shoot" animation
-		m_pPlayer->SetAnimation(PLAYER_ATTACK1);
+		m_hPlayer->SetAnimation(PLAYER_ATTACK1);
 
 		float flDamage = m_flStabBaseDamage;
 
@@ -539,11 +539,11 @@ BOOL CKnife::Stab(BOOL fFirst)
 			}
 		}
 
-		UTIL_MakeVectors(m_pPlayer->pev->v_angle);
+		UTIL_MakeVectors(m_hPlayer->pev->v_angle);
 		ClearMultiDamage();
 
-		pEntity->TraceAttack(m_pPlayer->pev, flDamage, gpGlobals->v_forward, &tr, (DMG_NEVERGIB | DMG_BULLET));
-		ApplyMultiDamage(m_pPlayer->pev, m_pPlayer->pev);
+		pEntity->TraceAttack(m_hPlayer->pev, flDamage, gpGlobals->v_forward, &tr, (DMG_NEVERGIB | DMG_BULLET));
+		ApplyMultiDamage(m_hPlayer->pev, m_hPlayer->pev);
 
 #ifndef REGAMEDLL_FIXES
 		if (pEntity)	// -V595
@@ -555,8 +555,8 @@ BOOL CKnife::Stab(BOOL fFirst)
 			if (pEntity->Classify() != CLASS_NONE && pEntity->Classify() != CLASS_MACHINE)
 #endif
 			{
-				EMIT_SOUND(m_pPlayer->edict(), CHAN_WEAPON, "weapons/knife_stab.wav", VOL_NORM, ATTN_NORM);
-				m_pPlayer->m_iWeaponVolume = KNIFE_BODYHIT_VOLUME;
+				EMIT_SOUND(m_hPlayer->edict(), CHAN_WEAPON, "weapons/knife_stab.wav", VOL_NORM, ATTN_NORM);
+				m_hPlayer->m_iWeaponVolume = KNIFE_BODYHIT_VOLUME;
 
 				if (!pEntity->IsAlive())
 					return TRUE;
@@ -585,7 +585,7 @@ BOOL CKnife::Stab(BOOL fFirst)
 		{
 			// delay the decal a bit
 			m_trHit = tr;
-			m_pPlayer->m_iWeaponVolume = int(flVol * KNIFE_WALLHIT_VOLUME);
+			m_hPlayer->m_iWeaponVolume = int(flVol * KNIFE_WALLHIT_VOLUME);
 
 			SetThink(&CKnife::Smack);
 			pev->nextthink = UTIL_WeaponTimeBase() + 0.2f;
@@ -595,7 +595,7 @@ BOOL CKnife::Stab(BOOL fFirst)
 		else
 		{
 			// also play knife strike
-			EMIT_SOUND_DYN(m_pPlayer->edict(), CHAN_ITEM, "weapons/knife_hitwall1.wav", VOL_NORM, ATTN_NORM, 0, RANDOM_LONG(0, 3) + 98);
+			EMIT_SOUND_DYN(m_hPlayer->edict(), CHAN_ITEM, "weapons/knife_hitwall1.wav", VOL_NORM, ATTN_NORM, 0, RANDOM_LONG(0, 3) + 98);
 		}
 	}
 

--- a/regamedll/dlls/wpn_shared/wpn_m249.cpp
+++ b/regamedll/dlls/wpn_shared/wpn_m249.cpp
@@ -69,11 +69,11 @@ BOOL CM249::Deploy()
 
 void CM249::PrimaryAttack()
 {
-	if (!(m_pPlayer->pev->flags & FL_ONGROUND))
+	if (!(m_hPlayer->pev->flags & FL_ONGROUND))
 	{
 		M249Fire(0.045 + (0.5 * m_flAccuracy), 0.1, FALSE);
 	}
-	else if (m_pPlayer->pev->velocity.Length2D() > 140)
+	else if (m_hPlayer->pev->velocity.Length2D() > 140)
 	{
 		M249Fire(0.045 + (0.095 * m_flAccuracy), 0.1, FALSE);
 	}
@@ -106,22 +106,22 @@ void CM249::M249Fire(float flSpread, float flCycleTime, BOOL fUseAutoAim)
 
 		if (TheBots)
 		{
-			TheBots->OnEvent(EVENT_WEAPON_FIRED_ON_EMPTY, m_pPlayer);
+			TheBots->OnEvent(EVENT_WEAPON_FIRED_ON_EMPTY, m_hPlayer);
 		}
 
 		return;
 	}
 
 	m_iClip--;
-	m_pPlayer->pev->effects |= EF_MUZZLEFLASH;
-	m_pPlayer->SetAnimation(PLAYER_ATTACK1);
+	m_hPlayer->pev->effects |= EF_MUZZLEFLASH;
+	m_hPlayer->SetAnimation(PLAYER_ATTACK1);
 
-	UTIL_MakeVectors(m_pPlayer->pev->v_angle + m_pPlayer->pev->punchangle);
+	UTIL_MakeVectors(m_hPlayer->pev->v_angle + m_hPlayer->pev->punchangle);
 
-	m_pPlayer->m_iWeaponVolume = NORMAL_GUN_VOLUME;
-	m_pPlayer->m_iWeaponFlash = BRIGHT_GUN_FLASH;
+	m_hPlayer->m_iWeaponVolume = NORMAL_GUN_VOLUME;
+	m_hPlayer->m_iWeaponFlash = BRIGHT_GUN_FLASH;
 
-	vecSrc = m_pPlayer->GetGunPosition();
+	vecSrc = m_hPlayer->GetGunPosition();
 	vecAiming = gpGlobals->v_forward;
 
 #ifdef REGAMEDLL_API
@@ -129,8 +129,8 @@ void CM249::M249Fire(float flSpread, float flCycleTime, BOOL fUseAutoAim)
 #else
 	float flBaseDamage = M249_DAMAGE;
 #endif
-	vecDir = m_pPlayer->FireBullets3(vecSrc, vecAiming, flSpread, 8192, 2, BULLET_PLAYER_556MM,
-		flBaseDamage, M249_RANGE_MODIFER, m_pPlayer->pev, false, m_pPlayer->random_seed);
+	vecDir = m_hPlayer->FireBullets3(vecSrc, vecAiming, flSpread, 8192, 2, BULLET_PLAYER_556MM,
+		flBaseDamage, M249_RANGE_MODIFER, m_hPlayer->pev, false, m_hPlayer->random_seed);
 
 #ifdef CLIENT_WEAPONS
 	flag = FEV_NOTHOST;
@@ -138,27 +138,27 @@ void CM249::M249Fire(float flSpread, float flCycleTime, BOOL fUseAutoAim)
 	flag = 0;
 #endif
 
-	PLAYBACK_EVENT_FULL(flag, m_pPlayer->edict(), m_usFireM249, 0, (float *)&g_vecZero, (float *)&g_vecZero, vecDir.x, vecDir.y,
-		int(m_pPlayer->pev->punchangle.x * 100), int(m_pPlayer->pev->punchangle.y * 100), FALSE, FALSE);
+	PLAYBACK_EVENT_FULL(flag, m_hPlayer->edict(), m_usFireM249, 0, (float *)&g_vecZero, (float *)&g_vecZero, vecDir.x, vecDir.y,
+		int(m_hPlayer->pev->punchangle.x * 100), int(m_hPlayer->pev->punchangle.y * 100), FALSE, FALSE);
 
 	m_flNextPrimaryAttack = m_flNextSecondaryAttack = GetNextAttackDelay(flCycleTime);
 
-	if (!m_iClip && m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType] <= 0)
+	if (!m_iClip && m_hPlayer->m_rgAmmo[m_iPrimaryAmmoType] <= 0)
 	{
-		m_pPlayer->SetSuitUpdate("!HEV_AMO0", SUIT_SENTENCE, SUIT_REPEAT_OK);
+		m_hPlayer->SetSuitUpdate("!HEV_AMO0", SUIT_SENTENCE, SUIT_REPEAT_OK);
 	}
 
 	m_flTimeWeaponIdle = UTIL_WeaponTimeBase() + 1.6f;
 
-	if (!(m_pPlayer->pev->flags & FL_ONGROUND))
+	if (!(m_hPlayer->pev->flags & FL_ONGROUND))
 	{
 		KickBack(1.8, 0.65, 0.45, 0.125, 5.0, 3.5, 8);
 	}
-	else if (m_pPlayer->pev->velocity.Length2D() > 0)
+	else if (m_hPlayer->pev->velocity.Length2D() > 0)
 	{
 		KickBack(1.1, 0.5, 0.3, 0.06, 4.0, 3.0, 8);
 	}
-	else if (m_pPlayer->pev->flags & FL_DUCKING)
+	else if (m_hPlayer->pev->flags & FL_DUCKING)
 	{
 		KickBack(0.75, 0.325, 0.25, 0.025, 3.5, 2.5, 9);
 	}
@@ -172,13 +172,13 @@ void CM249::Reload()
 {
 #ifdef REGAMEDLL_FIXES
 	// to prevent reload if not enough ammo
-	if (m_pPlayer->ammo_556natobox <= 0)
+	if (m_hPlayer->ammo_556natobox <= 0)
 		return;
 #endif
 
 	if (DefaultReload(iMaxClip(), M249_RELOAD, M249_RELOAD_TIME))
 	{
-		m_pPlayer->SetAnimation(PLAYER_RELOAD);
+		m_hPlayer->SetAnimation(PLAYER_RELOAD);
 
 		m_flAccuracy = 0.2f;
 		m_bDelayFire = false;
@@ -189,7 +189,7 @@ void CM249::Reload()
 void CM249::WeaponIdle()
 {
 	ResetEmptySound();
-	m_pPlayer->GetAutoaimVector(AUTOAIM_10DEGREES);
+	m_hPlayer->GetAutoaimVector(AUTOAIM_10DEGREES);
 
 	if (m_flTimeWeaponIdle > UTIL_WeaponTimeBase())
 	{

--- a/regamedll/dlls/wpn_shared/wpn_m3.cpp
+++ b/regamedll/dlls/wpn_shared/wpn_m3.cpp
@@ -81,7 +81,7 @@ void CM3::PrimaryAttack()
 
 			if (TheBots)
 			{
-				TheBots->OnEvent(EVENT_WEAPON_FIRED_ON_EMPTY, m_pPlayer);
+				TheBots->OnEvent(EVENT_WEAPON_FIRED_ON_EMPTY, m_hPlayer);
 			}
 		}
 
@@ -96,7 +96,7 @@ void CM3::PrimaryAttack()
 
 		if (TheBots)
 		{
-			TheBots->OnEvent(EVENT_WEAPON_FIRED_ON_EMPTY, m_pPlayer);
+			TheBots->OnEvent(EVENT_WEAPON_FIRED_ON_EMPTY, m_hPlayer);
 		}
 
 		m_flNextPrimaryAttack = GetNextAttackDelay(1);
@@ -106,16 +106,16 @@ void CM3::PrimaryAttack()
 	}
 
 	m_iClip--;
-	m_pPlayer->m_iWeaponVolume = LOUD_GUN_VOLUME;
-	m_pPlayer->m_iWeaponFlash = BRIGHT_GUN_FLASH;
+	m_hPlayer->m_iWeaponVolume = LOUD_GUN_VOLUME;
+	m_hPlayer->m_iWeaponFlash = BRIGHT_GUN_FLASH;
 
-	m_pPlayer->pev->effects |= EF_MUZZLEFLASH;
+	m_hPlayer->pev->effects |= EF_MUZZLEFLASH;
 	// player "shoot" animation
-	m_pPlayer->SetAnimation(PLAYER_ATTACK1);
+	m_hPlayer->SetAnimation(PLAYER_ATTACK1);
 
-	UTIL_MakeVectors(m_pPlayer->pev->v_angle + m_pPlayer->pev->punchangle);
+	UTIL_MakeVectors(m_hPlayer->pev->v_angle + m_hPlayer->pev->punchangle);
 
-	vecSrc = m_pPlayer->GetGunPosition();
+	vecSrc = m_hPlayer->GetGunPosition();
 	vecAiming = gpGlobals->v_forward;
 
 #ifdef REGAMEDLL_API
@@ -127,9 +127,9 @@ void CM3::PrimaryAttack()
 	Vector vecCone(M3_CONE_VECTOR);
 
 #ifdef REGAMEDLL_FIXES
-	m_pPlayer->FireBuckshots(9, vecSrc, vecAiming, vecCone, 3000.0f, 0, flBaseDamage, m_pPlayer->pev);
+	m_hPlayer->FireBuckshots(9, vecSrc, vecAiming, vecCone, 3000.0f, 0, flBaseDamage, m_hPlayer->pev);
 #else
-	m_pPlayer->FireBullets(9, vecSrc, vecAiming, vecCone, 3000, BULLET_PLAYER_BUCKSHOT, 0, 0, NULL);
+	m_hPlayer->FireBullets(9, vecSrc, vecAiming, vecCone, 3000, BULLET_PLAYER_BUCKSHOT, 0, 0, NULL);
 #endif
 
 #ifdef CLIENT_WEAPONS
@@ -140,16 +140,16 @@ void CM3::PrimaryAttack()
 
 #ifdef REGAMEDLL_ADD
 	// HACKHACK: client-side weapon prediction fix
-	if (!(iFlags() & ITEM_FLAG_NOFIREUNDERWATER) && m_pPlayer->pev->waterlevel == 3)
+	if (!(iFlags() & ITEM_FLAG_NOFIREUNDERWATER) && m_hPlayer->pev->waterlevel == 3)
 		flag = 0;
 #endif
 
-	PLAYBACK_EVENT_FULL(flag, m_pPlayer->edict(), m_usFireM3, 0, (float *)&g_vecZero, (float *)&g_vecZero, 0, 0, 0, 0, FALSE, FALSE);
+	PLAYBACK_EVENT_FULL(flag, m_hPlayer->edict(), m_usFireM3, 0, (float *)&g_vecZero, (float *)&g_vecZero, 0, 0, 0, 0, FALSE, FALSE);
 
-	if (!m_iClip && m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType] <= 0)
+	if (!m_iClip && m_hPlayer->m_rgAmmo[m_iPrimaryAmmoType] <= 0)
 	{
 		// HEV suit - indicate out of ammo condition
-		m_pPlayer->SetSuitUpdate("!HEV_AMO0", SUIT_SENTENCE, SUIT_REPEAT_OK);
+		m_hPlayer->SetSuitUpdate("!HEV_AMO0", SUIT_SENTENCE, SUIT_REPEAT_OK);
 	}
 
 #ifndef REGAMEDLL_FIXES
@@ -167,12 +167,12 @@ void CM3::PrimaryAttack()
 
 	m_fInSpecialReload = 0;
 
-	if (m_pPlayer->pev->flags & FL_ONGROUND)
-		m_pPlayer->pev->punchangle.x -= UTIL_SharedRandomLong(m_pPlayer->random_seed + 1, 4, 6);
+	if (m_hPlayer->pev->flags & FL_ONGROUND)
+		m_hPlayer->pev->punchangle.x -= UTIL_SharedRandomLong(m_hPlayer->random_seed + 1, 4, 6);
 	else
-		m_pPlayer->pev->punchangle.x -= UTIL_SharedRandomLong(m_pPlayer->random_seed + 1, 8, 11);
+		m_hPlayer->pev->punchangle.x -= UTIL_SharedRandomLong(m_hPlayer->random_seed + 1, 8, 11);
 
-	m_pPlayer->m_flEjectBrass = gpGlobals->time + 0.45f;
+	m_hPlayer->m_flEjectBrass = gpGlobals->time + 0.45f;
 }
 
 void CM3::Reload()
@@ -186,7 +186,7 @@ void CM3::Reload()
 void CM3::WeaponIdle()
 {
 	ResetEmptySound();
-	m_pPlayer->GetAutoaimVector(AUTOAIM_5DEGREES);
+	m_hPlayer->GetAutoaimVector(AUTOAIM_5DEGREES);
 
 #ifndef REGAMEDLL_FIXES
 	if (m_flPumpTime && m_flPumpTime < UTIL_WeaponTimeBase())
@@ -197,13 +197,13 @@ void CM3::WeaponIdle()
 
 	if (m_flTimeWeaponIdle < UTIL_WeaponTimeBase())
 	{
-		if (m_iClip == 0 && m_fInSpecialReload == 0 && m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType])
+		if (m_iClip == 0 && m_fInSpecialReload == 0 && m_hPlayer->m_rgAmmo[m_iPrimaryAmmoType])
 		{
 			Reload();
 		}
 		else if (m_fInSpecialReload != 0)
 		{
-			if (m_iClip != iMaxClip() && m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType])
+			if (m_iClip != iMaxClip() && m_hPlayer->m_rgAmmo[m_iPrimaryAmmoType])
 			{
 				Reload();
 			}

--- a/regamedll/dlls/wpn_shared/wpn_m4a1.cpp
+++ b/regamedll/dlls/wpn_shared/wpn_m4a1.cpp
@@ -82,13 +82,13 @@ void CM4A1::SecondaryAttack()
 	{
 		m_iWeaponState &= ~WPNSTATE_M4A1_SILENCED;
 		SendWeaponAnim(M4A1_DETACH_SILENCER, UseDecrement() != FALSE);
-		Q_strcpy(m_pPlayer->m_szAnimExtention, "rifle");
+		Q_strcpy(m_hPlayer->m_szAnimExtention, "rifle");
 	}
 	else
 	{
 		m_iWeaponState |= WPNSTATE_M4A1_SILENCED;
 		SendWeaponAnim(M4A1_ATTACH_SILENCER, UseDecrement() != FALSE);
-		Q_strcpy(m_pPlayer->m_szAnimExtention, "rifle");
+		Q_strcpy(m_hPlayer->m_szAnimExtention, "rifle");
 	}
 
 	m_flTimeWeaponIdle = m_flNextSecondaryAttack = UTIL_WeaponTimeBase() + 2.0f;
@@ -99,11 +99,11 @@ void CM4A1::PrimaryAttack()
 {
 	if (m_iWeaponState & WPNSTATE_M4A1_SILENCED)
 	{
-		if (!(m_pPlayer->pev->flags & FL_ONGROUND))
+		if (!(m_hPlayer->pev->flags & FL_ONGROUND))
 		{
 			M4A1Fire(0.035 + (0.4 * m_flAccuracy), 0.0875, FALSE);
 		}
-		else if (m_pPlayer->pev->velocity.Length2D() > 140)
+		else if (m_hPlayer->pev->velocity.Length2D() > 140)
 		{
 			M4A1Fire(0.035 + (0.07 * m_flAccuracy), 0.0875, FALSE);
 		}
@@ -114,11 +114,11 @@ void CM4A1::PrimaryAttack()
 	}
 	else
 	{
-		if (!(m_pPlayer->pev->flags & FL_ONGROUND))
+		if (!(m_hPlayer->pev->flags & FL_ONGROUND))
 		{
 			M4A1Fire(0.035 + (0.4 * m_flAccuracy), 0.0875, FALSE);
 		}
-		else if (m_pPlayer->pev->velocity.Length2D() > 140)
+		else if (m_hPlayer->pev->velocity.Length2D() > 140)
 		{
 			M4A1Fire(0.035 + (0.07 * m_flAccuracy), 0.0875, FALSE);
 		}
@@ -152,21 +152,21 @@ void CM4A1::M4A1Fire(float flSpread, float flCycleTime, BOOL fUseAutoAim)
 
 		if (TheBots)
 		{
-			TheBots->OnEvent(EVENT_WEAPON_FIRED_ON_EMPTY, m_pPlayer);
+			TheBots->OnEvent(EVENT_WEAPON_FIRED_ON_EMPTY, m_hPlayer);
 		}
 
 		return;
 	}
 
 	m_iClip--;
-	m_pPlayer->SetAnimation(PLAYER_ATTACK1);
+	m_hPlayer->SetAnimation(PLAYER_ATTACK1);
 
-	UTIL_MakeVectors(m_pPlayer->pev->v_angle + m_pPlayer->pev->punchangle);
+	UTIL_MakeVectors(m_hPlayer->pev->v_angle + m_hPlayer->pev->punchangle);
 
-	m_pPlayer->m_iWeaponVolume = NORMAL_GUN_VOLUME;
-	m_pPlayer->m_iWeaponFlash = BRIGHT_GUN_FLASH;
+	m_hPlayer->m_iWeaponVolume = NORMAL_GUN_VOLUME;
+	m_hPlayer->m_iWeaponFlash = BRIGHT_GUN_FLASH;
 
-	vecSrc = m_pPlayer->GetGunPosition();
+	vecSrc = m_hPlayer->GetGunPosition();
 	vecAiming = gpGlobals->v_forward;
 
 #ifdef REGAMEDLL_API
@@ -176,15 +176,15 @@ void CM4A1::M4A1Fire(float flSpread, float flCycleTime, BOOL fUseAutoAim)
 #endif
 	if (m_iWeaponState & WPNSTATE_M4A1_SILENCED)
 	{
-		vecDir = m_pPlayer->FireBullets3(vecSrc, vecAiming, flSpread, 8192, 2, BULLET_PLAYER_556MM,
-			flBaseDamage, M4A1_RANGE_MODIFER_SIL, m_pPlayer->pev, false, m_pPlayer->random_seed);
+		vecDir = m_hPlayer->FireBullets3(vecSrc, vecAiming, flSpread, 8192, 2, BULLET_PLAYER_556MM,
+			flBaseDamage, M4A1_RANGE_MODIFER_SIL, m_hPlayer->pev, false, m_hPlayer->random_seed);
 	}
 	else
 	{
-		vecDir = m_pPlayer->FireBullets3(vecSrc, vecAiming, flSpread, 8192, 2, BULLET_PLAYER_556MM,
-			flBaseDamage, M4A1_RANGE_MODIFER, m_pPlayer->pev, false, m_pPlayer->random_seed);
+		vecDir = m_hPlayer->FireBullets3(vecSrc, vecAiming, flSpread, 8192, 2, BULLET_PLAYER_556MM,
+			flBaseDamage, M4A1_RANGE_MODIFER, m_hPlayer->pev, false, m_hPlayer->random_seed);
 
-		m_pPlayer->pev->effects |= EF_MUZZLEFLASH;
+		m_hPlayer->pev->effects |= EF_MUZZLEFLASH;
 	}
 
 #ifdef CLIENT_WEAPONS
@@ -194,30 +194,30 @@ void CM4A1::M4A1Fire(float flSpread, float flCycleTime, BOOL fUseAutoAim)
 #endif
 
 #ifndef REGAMEDLL_FIXES
-	m_pPlayer->ammo_556nato--;
+	m_hPlayer->ammo_556nato--;
 #endif
 
-	PLAYBACK_EVENT_FULL(flag, m_pPlayer->edict(), m_usFireM4A1, 0, (float *)&g_vecZero, (float *)&g_vecZero, vecDir.x, vecDir.y,
-		int(m_pPlayer->pev->punchangle.x * 100), int(m_pPlayer->pev->punchangle.y * 100), (m_iWeaponState & WPNSTATE_M4A1_SILENCED) == WPNSTATE_M4A1_SILENCED, FALSE);
+	PLAYBACK_EVENT_FULL(flag, m_hPlayer->edict(), m_usFireM4A1, 0, (float *)&g_vecZero, (float *)&g_vecZero, vecDir.x, vecDir.y,
+		int(m_hPlayer->pev->punchangle.x * 100), int(m_hPlayer->pev->punchangle.y * 100), (m_iWeaponState & WPNSTATE_M4A1_SILENCED) == WPNSTATE_M4A1_SILENCED, FALSE);
 
 	m_flNextPrimaryAttack = m_flNextSecondaryAttack = GetNextAttackDelay(flCycleTime);
 
-	if (!m_iClip && m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType] <= 0)
+	if (!m_iClip && m_hPlayer->m_rgAmmo[m_iPrimaryAmmoType] <= 0)
 	{
-		m_pPlayer->SetSuitUpdate("!HEV_AMO0", SUIT_SENTENCE, SUIT_REPEAT_OK);
+		m_hPlayer->SetSuitUpdate("!HEV_AMO0", SUIT_SENTENCE, SUIT_REPEAT_OK);
 	}
 
 	m_flTimeWeaponIdle = UTIL_WeaponTimeBase() + 1.5f;
 
-	if (m_pPlayer->pev->velocity.Length2D() > 0)
+	if (m_hPlayer->pev->velocity.Length2D() > 0)
 	{
 		KickBack(1.0, 0.45, 0.28, 0.045, 3.75, 3.0, 7);
 	}
-	else if (!(m_pPlayer->pev->flags & FL_ONGROUND))
+	else if (!(m_hPlayer->pev->flags & FL_ONGROUND))
 	{
 		KickBack(1.2, 0.5, 0.23, 0.15, 5.5, 3.5, 6);
 	}
-	else if (m_pPlayer->pev->flags & FL_DUCKING)
+	else if (m_hPlayer->pev->flags & FL_DUCKING)
 	{
 		KickBack(0.6, 0.3, 0.2, 0.0125, 3.25, 2.0, 7);
 	}
@@ -229,12 +229,12 @@ void CM4A1::M4A1Fire(float flSpread, float flCycleTime, BOOL fUseAutoAim)
 
 void CM4A1::Reload()
 {
-	if (m_pPlayer->ammo_556nato <= 0)
+	if (m_hPlayer->ammo_556nato <= 0)
 		return;
 
 	if (DefaultReload(iMaxClip(), ((m_iWeaponState & WPNSTATE_M4A1_SILENCED) == WPNSTATE_M4A1_SILENCED) ? M4A1_RELOAD : M4A1_UNSIL_RELOAD, M4A1_RELOAD_TIME))
 	{
-		m_pPlayer->SetAnimation(PLAYER_RELOAD);
+		m_hPlayer->SetAnimation(PLAYER_RELOAD);
 
 		m_flAccuracy = 0.2f;
 		m_iShotsFired = 0;
@@ -245,7 +245,7 @@ void CM4A1::Reload()
 void CM4A1::WeaponIdle()
 {
 	ResetEmptySound();
-	m_pPlayer->GetAutoaimVector(AUTOAIM_10DEGREES);
+	m_hPlayer->GetAutoaimVector(AUTOAIM_10DEGREES);
 
 	if (m_flTimeWeaponIdle > UTIL_WeaponTimeBase())
 	{

--- a/regamedll/dlls/wpn_shared/wpn_mac10.cpp
+++ b/regamedll/dlls/wpn_shared/wpn_mac10.cpp
@@ -66,7 +66,7 @@ BOOL CMAC10::Deploy()
 
 void CMAC10::PrimaryAttack()
 {
-	if (!(m_pPlayer->pev->flags & FL_ONGROUND))
+	if (!(m_hPlayer->pev->flags & FL_ONGROUND))
 	{
 		MAC10Fire(0.375 * m_flAccuracy, 0.07, FALSE);
 	}
@@ -99,22 +99,22 @@ void CMAC10::MAC10Fire(float flSpread, float flCycleTime, BOOL fUseAutoAim)
 
 		if (TheBots)
 		{
-			TheBots->OnEvent(EVENT_WEAPON_FIRED_ON_EMPTY, m_pPlayer);
+			TheBots->OnEvent(EVENT_WEAPON_FIRED_ON_EMPTY, m_hPlayer);
 		}
 
 		return;
 	}
 
 	m_iClip--;
-	m_pPlayer->pev->effects |= EF_MUZZLEFLASH;
-	m_pPlayer->SetAnimation(PLAYER_ATTACK1);
+	m_hPlayer->pev->effects |= EF_MUZZLEFLASH;
+	m_hPlayer->SetAnimation(PLAYER_ATTACK1);
 
-	UTIL_MakeVectors(m_pPlayer->pev->v_angle + m_pPlayer->pev->punchangle);
+	UTIL_MakeVectors(m_hPlayer->pev->v_angle + m_hPlayer->pev->punchangle);
 
-	m_pPlayer->m_iWeaponVolume = NORMAL_GUN_VOLUME;
-	m_pPlayer->m_iWeaponFlash = DIM_GUN_FLASH;
+	m_hPlayer->m_iWeaponVolume = NORMAL_GUN_VOLUME;
+	m_hPlayer->m_iWeaponFlash = DIM_GUN_FLASH;
 
-	vecSrc = m_pPlayer->GetGunPosition();
+	vecSrc = m_hPlayer->GetGunPosition();
 	vecAiming = gpGlobals->v_forward;
 
 #ifdef REGAMEDLL_API
@@ -122,8 +122,8 @@ void CMAC10::MAC10Fire(float flSpread, float flCycleTime, BOOL fUseAutoAim)
 #else
 	float flBaseDamage = MAC10_DAMAGE;
 #endif
-	vecDir = m_pPlayer->FireBullets3(vecSrc, vecAiming, flSpread, 8192, 1, BULLET_PLAYER_45ACP,
-		flBaseDamage, MAC10_RANGE_MODIFER, m_pPlayer->pev, false, m_pPlayer->random_seed);
+	vecDir = m_hPlayer->FireBullets3(vecSrc, vecAiming, flSpread, 8192, 1, BULLET_PLAYER_45ACP,
+		flBaseDamage, MAC10_RANGE_MODIFER, m_hPlayer->pev, false, m_hPlayer->random_seed);
 
 #ifdef CLIENT_WEAPONS
 	flag = FEV_NOTHOST;
@@ -131,27 +131,27 @@ void CMAC10::MAC10Fire(float flSpread, float flCycleTime, BOOL fUseAutoAim)
 	flag = 0;
 #endif
 
-	PLAYBACK_EVENT_FULL(flag, m_pPlayer->edict(), m_usFireMAC10, 0, (float *)&g_vecZero, (float *)&g_vecZero, vecDir.x, vecDir.y,
-		int(m_pPlayer->pev->punchangle.x * 100), int(m_pPlayer->pev->punchangle.y * 100), FALSE, FALSE);
+	PLAYBACK_EVENT_FULL(flag, m_hPlayer->edict(), m_usFireMAC10, 0, (float *)&g_vecZero, (float *)&g_vecZero, vecDir.x, vecDir.y,
+		int(m_hPlayer->pev->punchangle.x * 100), int(m_hPlayer->pev->punchangle.y * 100), FALSE, FALSE);
 
 	m_flNextPrimaryAttack = m_flNextSecondaryAttack = GetNextAttackDelay(flCycleTime);
 
-	if (!m_iClip && m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType] <= 0)
+	if (!m_iClip && m_hPlayer->m_rgAmmo[m_iPrimaryAmmoType] <= 0)
 	{
-		m_pPlayer->SetSuitUpdate("!HEV_AMO0", SUIT_SENTENCE, SUIT_REPEAT_OK);
+		m_hPlayer->SetSuitUpdate("!HEV_AMO0", SUIT_SENTENCE, SUIT_REPEAT_OK);
 	}
 
 	m_flTimeWeaponIdle = UTIL_WeaponTimeBase() + 2.0f;
 
-	if (!(m_pPlayer->pev->flags & FL_ONGROUND))
+	if (!(m_hPlayer->pev->flags & FL_ONGROUND))
 	{
 		KickBack(1.3, 0.55, 0.4, 0.05, 4.75, 3.75, 5);
 	}
-	else if (m_pPlayer->pev->velocity.Length2D() > 0)
+	else if (m_hPlayer->pev->velocity.Length2D() > 0)
 	{
 		KickBack(0.9, 0.45, 0.25, 0.035, 3.5, 2.75, 7);
 	}
-	else if (m_pPlayer->pev->flags & FL_DUCKING)
+	else if (m_hPlayer->pev->flags & FL_DUCKING)
 	{
 		KickBack(0.75, 0.4, 0.175, 0.03, 2.75, 2.5, 10);
 	}
@@ -163,12 +163,12 @@ void CMAC10::MAC10Fire(float flSpread, float flCycleTime, BOOL fUseAutoAim)
 
 void CMAC10::Reload()
 {
-	if (m_pPlayer->ammo_45acp <= 0)
+	if (m_hPlayer->ammo_45acp <= 0)
 		return;
 
 	if (DefaultReload(iMaxClip(), MAC10_RELOAD, MAC10_RELOAD_TIME))
 	{
-		m_pPlayer->SetAnimation(PLAYER_RELOAD);
+		m_hPlayer->SetAnimation(PLAYER_RELOAD);
 
 		m_flAccuracy = 0;
 		m_iShotsFired = 0;
@@ -178,7 +178,7 @@ void CMAC10::Reload()
 void CMAC10::WeaponIdle()
 {
 	ResetEmptySound();
-	m_pPlayer->GetAutoaimVector(AUTOAIM_10DEGREES);
+	m_hPlayer->GetAutoaimVector(AUTOAIM_10DEGREES);
 
 	if (m_flTimeWeaponIdle > UTIL_WeaponTimeBase())
 	{

--- a/regamedll/dlls/wpn_shared/wpn_mp5navy.cpp
+++ b/regamedll/dlls/wpn_shared/wpn_mp5navy.cpp
@@ -67,7 +67,7 @@ BOOL CMP5N::Deploy()
 
 void CMP5N::PrimaryAttack()
 {
-	if (!(m_pPlayer->pev->flags & FL_ONGROUND))
+	if (!(m_hPlayer->pev->flags & FL_ONGROUND))
 	{
 		MP5NFire(0.2 * m_flAccuracy, 0.075, FALSE);
 	}
@@ -100,19 +100,19 @@ void CMP5N::MP5NFire(float flSpread, float flCycleTime, BOOL fUseAutoAim)
 
 		if (TheBots)
 		{
-			TheBots->OnEvent(EVENT_WEAPON_FIRED_ON_EMPTY, m_pPlayer);
+			TheBots->OnEvent(EVENT_WEAPON_FIRED_ON_EMPTY, m_hPlayer);
 		}
 
 		return;
 	}
 
 	m_iClip--;
-	m_pPlayer->pev->effects |= EF_MUZZLEFLASH;
-	m_pPlayer->SetAnimation(PLAYER_ATTACK1);
+	m_hPlayer->pev->effects |= EF_MUZZLEFLASH;
+	m_hPlayer->SetAnimation(PLAYER_ATTACK1);
 
-	UTIL_MakeVectors(m_pPlayer->pev->v_angle + m_pPlayer->pev->punchangle);
+	UTIL_MakeVectors(m_hPlayer->pev->v_angle + m_hPlayer->pev->punchangle);
 
-	vecSrc = m_pPlayer->GetGunPosition();
+	vecSrc = m_hPlayer->GetGunPosition();
 	vecAiming = gpGlobals->v_forward;
 
 #ifdef REGAMEDLL_API
@@ -120,8 +120,8 @@ void CMP5N::MP5NFire(float flSpread, float flCycleTime, BOOL fUseAutoAim)
 #else
 	float flBaseDamage = MP5N_DAMAGE;
 #endif
-	vecDir = m_pPlayer->FireBullets3(vecSrc, vecAiming, flSpread, 8192, 1, BULLET_PLAYER_9MM,
-		flBaseDamage, MP5N_RANGE_MODIFER, m_pPlayer->pev, false, m_pPlayer->random_seed);
+	vecDir = m_hPlayer->FireBullets3(vecSrc, vecAiming, flSpread, 8192, 1, BULLET_PLAYER_9MM,
+		flBaseDamage, MP5N_RANGE_MODIFER, m_hPlayer->pev, false, m_hPlayer->random_seed);
 
 #ifdef CLIENT_WEAPONS
 	flag = FEV_NOTHOST;
@@ -129,30 +129,30 @@ void CMP5N::MP5NFire(float flSpread, float flCycleTime, BOOL fUseAutoAim)
 	flag = 0;
 #endif
 
-	PLAYBACK_EVENT_FULL(flag, m_pPlayer->edict(), m_usFireMP5N, 0, (float *)&g_vecZero, (float *)&g_vecZero, vecDir.x, vecDir.y,
-		int(m_pPlayer->pev->punchangle.x * 100), int(m_pPlayer->pev->punchangle.y * 100), FALSE, FALSE);
+	PLAYBACK_EVENT_FULL(flag, m_hPlayer->edict(), m_usFireMP5N, 0, (float *)&g_vecZero, (float *)&g_vecZero, vecDir.x, vecDir.y,
+		int(m_hPlayer->pev->punchangle.x * 100), int(m_hPlayer->pev->punchangle.y * 100), FALSE, FALSE);
 
-	m_pPlayer->m_iWeaponVolume = NORMAL_GUN_VOLUME;
-	m_pPlayer->m_iWeaponFlash = DIM_GUN_FLASH;
+	m_hPlayer->m_iWeaponVolume = NORMAL_GUN_VOLUME;
+	m_hPlayer->m_iWeaponFlash = DIM_GUN_FLASH;
 
 	m_flNextPrimaryAttack = m_flNextSecondaryAttack = GetNextAttackDelay(flCycleTime);
 
-	if (!m_iClip && m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType] <= 0)
+	if (!m_iClip && m_hPlayer->m_rgAmmo[m_iPrimaryAmmoType] <= 0)
 	{
-		m_pPlayer->SetSuitUpdate("!HEV_AMO0", SUIT_SENTENCE, SUIT_REPEAT_OK);
+		m_hPlayer->SetSuitUpdate("!HEV_AMO0", SUIT_SENTENCE, SUIT_REPEAT_OK);
 	}
 
 	m_flTimeWeaponIdle = UTIL_WeaponTimeBase() + 2.0f;
 
-	if (!(m_pPlayer->pev->flags & FL_ONGROUND))
+	if (!(m_hPlayer->pev->flags & FL_ONGROUND))
 	{
 		KickBack(0.9, 0.475, 0.35, 0.0425, 5.0, 3.0, 6);
 	}
-	else if (m_pPlayer->pev->velocity.Length2D() > 0)
+	else if (m_hPlayer->pev->velocity.Length2D() > 0)
 	{
 		KickBack(0.5, 0.275, 0.2, 0.03, 3.0, 2.0, 10);
 	}
-	else if (m_pPlayer->pev->flags & FL_DUCKING)
+	else if (m_hPlayer->pev->flags & FL_DUCKING)
 	{
 		KickBack(0.225, 0.15, 0.1, 0.015, 2.0, 1.0, 10);
 	}
@@ -164,12 +164,12 @@ void CMP5N::MP5NFire(float flSpread, float flCycleTime, BOOL fUseAutoAim)
 
 void CMP5N::Reload()
 {
-	if (m_pPlayer->ammo_9mm <= 0)
+	if (m_hPlayer->ammo_9mm <= 0)
 		return;
 
 	if (DefaultReload(iMaxClip(), MP5N_RELOAD, MP5N_RELOAD_TIME))
 	{
-		m_pPlayer->SetAnimation(PLAYER_RELOAD);
+		m_hPlayer->SetAnimation(PLAYER_RELOAD);
 
 		m_flAccuracy = 0;
 		m_iShotsFired = 0;
@@ -179,7 +179,7 @@ void CMP5N::Reload()
 void CMP5N::WeaponIdle()
 {
 	ResetEmptySound();
-	m_pPlayer->GetAutoaimVector(AUTOAIM_10DEGREES);
+	m_hPlayer->GetAutoaimVector(AUTOAIM_10DEGREES);
 
 	if (m_flTimeWeaponIdle > UTIL_WeaponTimeBase())
 	{

--- a/regamedll/dlls/wpn_shared/wpn_p228.cpp
+++ b/regamedll/dlls/wpn_shared/wpn_p228.cpp
@@ -62,9 +62,9 @@ BOOL CP228::Deploy()
 	m_flAccuracy = 0.9f;
 	m_fMaxSpeed = P228_MAX_SPEED;
 	m_iWeaponState &= ~WPNSTATE_SHIELD_DRAWN;
-	m_pPlayer->m_bShieldDrawn = false;
+	m_hPlayer->m_bShieldDrawn = false;
 
-	if (m_pPlayer->HasShield())
+	if (m_hPlayer->HasShield())
 		return DefaultDeploy("models/shield/v_shield_p228.mdl", "models/shield/p_shield_p228.mdl", P228_SHIELD_DRAW, "shieldgun", UseDecrement() != FALSE);
 	else
 		return DefaultDeploy("models/v_p228.mdl", "models/p_p228.mdl", P228_DRAW, "onehanded", UseDecrement() != FALSE);
@@ -72,15 +72,15 @@ BOOL CP228::Deploy()
 
 void CP228::PrimaryAttack()
 {
-	if (!(m_pPlayer->pev->flags & FL_ONGROUND))
+	if (!(m_hPlayer->pev->flags & FL_ONGROUND))
 	{
 		P228Fire(1.5 * (1 - m_flAccuracy), 0.2, FALSE);
 	}
-	else if (m_pPlayer->pev->velocity.Length2D() > 0)
+	else if (m_hPlayer->pev->velocity.Length2D() > 0)
 	{
 		P228Fire(0.255 * (1 - m_flAccuracy), 0.2, FALSE);
 	}
-	else if (m_pPlayer->pev->flags & FL_DUCKING)
+	else if (m_hPlayer->pev->flags & FL_DUCKING)
 	{
 		P228Fire(0.075 * (1 - m_flAccuracy), 0.2, FALSE);
 	}
@@ -133,23 +133,23 @@ void CP228::P228Fire(float flSpread, float flCycleTime, BOOL fUseSemi)
 
 		if (TheBots)
 		{
-			TheBots->OnEvent(EVENT_WEAPON_FIRED_ON_EMPTY, m_pPlayer);
+			TheBots->OnEvent(EVENT_WEAPON_FIRED_ON_EMPTY, m_hPlayer);
 		}
 
 		return;
 	}
 
 	m_iClip--;
-	m_pPlayer->pev->effects |= EF_MUZZLEFLASH;
+	m_hPlayer->pev->effects |= EF_MUZZLEFLASH;
 	SetPlayerShieldAnim();
 
-	m_pPlayer->SetAnimation(PLAYER_ATTACK1);
-	UTIL_MakeVectors(m_pPlayer->pev->v_angle + m_pPlayer->pev->punchangle);
+	m_hPlayer->SetAnimation(PLAYER_ATTACK1);
+	UTIL_MakeVectors(m_hPlayer->pev->v_angle + m_hPlayer->pev->punchangle);
 
-	m_pPlayer->m_iWeaponVolume = BIG_EXPLOSION_VOLUME;
-	m_pPlayer->m_iWeaponFlash = DIM_GUN_FLASH;
+	m_hPlayer->m_iWeaponVolume = BIG_EXPLOSION_VOLUME;
+	m_hPlayer->m_iWeaponFlash = DIM_GUN_FLASH;
 
-	vecSrc = m_pPlayer->GetGunPosition();
+	vecSrc = m_hPlayer->GetGunPosition();
 	vecAiming = gpGlobals->v_forward;
 
 #ifdef REGAMEDLL_API
@@ -157,7 +157,7 @@ void CP228::P228Fire(float flSpread, float flCycleTime, BOOL fUseSemi)
 #else
 	float flBaseDamage = P228_DAMAGE;
 #endif
-	vecDir = m_pPlayer->FireBullets3(vecSrc, vecAiming, flSpread, 4096, 1, BULLET_PLAYER_357SIG, flBaseDamage, P228_RANGE_MODIFER, m_pPlayer->pev, true, m_pPlayer->random_seed);
+	vecDir = m_hPlayer->FireBullets3(vecSrc, vecAiming, flSpread, 4096, 1, BULLET_PLAYER_357SIG, flBaseDamage, P228_RANGE_MODIFER, m_hPlayer->pev, true, m_hPlayer->random_seed);
 
 #ifdef CLIENT_WEAPONS
 	flag = FEV_NOTHOST;
@@ -165,29 +165,29 @@ void CP228::P228Fire(float flSpread, float flCycleTime, BOOL fUseSemi)
 	flag = 0;
 #endif
 
-	PLAYBACK_EVENT_FULL(flag, m_pPlayer->edict(), m_usFireP228, 0, (float *)&g_vecZero, (float *)&g_vecZero, vecDir.x, vecDir.y,
-		int(m_pPlayer->pev->punchangle.x * 100), int(m_pPlayer->pev->punchangle.y * 100), m_iClip == 0, FALSE);
+	PLAYBACK_EVENT_FULL(flag, m_hPlayer->edict(), m_usFireP228, 0, (float *)&g_vecZero, (float *)&g_vecZero, vecDir.x, vecDir.y,
+		int(m_hPlayer->pev->punchangle.x * 100), int(m_hPlayer->pev->punchangle.y * 100), m_iClip == 0, FALSE);
 
 	m_flNextPrimaryAttack = m_flNextSecondaryAttack = GetNextAttackDelay(flCycleTime);
 
-	if (!m_iClip && m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType] <= 0)
+	if (!m_iClip && m_hPlayer->m_rgAmmo[m_iPrimaryAmmoType] <= 0)
 	{
-		m_pPlayer->SetSuitUpdate("!HEV_AMO0", SUIT_SENTENCE, SUIT_REPEAT_OK);
+		m_hPlayer->SetSuitUpdate("!HEV_AMO0", SUIT_SENTENCE, SUIT_REPEAT_OK);
 	}
 
 	m_flTimeWeaponIdle = UTIL_WeaponTimeBase() + 2.0f;
-	m_pPlayer->pev->punchangle.x -= 2;
+	m_hPlayer->pev->punchangle.x -= 2;
 	ResetPlayerShieldAnim();
 }
 
 void CP228::Reload()
 {
-	if (m_pPlayer->ammo_357sig <= 0)
+	if (m_hPlayer->ammo_357sig <= 0)
 		return;
 
-	if (DefaultReload(iMaxClip(), m_pPlayer->HasShield() ? P228_SHIELD_RELOAD : P228_RELOAD, P228_RELOAD_TIME))
+	if (DefaultReload(iMaxClip(), m_hPlayer->HasShield() ? P228_SHIELD_RELOAD : P228_RELOAD, P228_RELOAD_TIME))
 	{
-		m_pPlayer->SetAnimation(PLAYER_RELOAD);
+		m_hPlayer->SetAnimation(PLAYER_RELOAD);
 		m_flAccuracy = 0.9f;
 	}
 }
@@ -195,14 +195,14 @@ void CP228::Reload()
 void CP228::WeaponIdle()
 {
 	ResetEmptySound();
-	m_pPlayer->GetAutoaimVector(AUTOAIM_10DEGREES);
+	m_hPlayer->GetAutoaimVector(AUTOAIM_10DEGREES);
 
 	if (m_flTimeWeaponIdle > UTIL_WeaponTimeBase())
 	{
 		return;
 	}
 
-	if (m_pPlayer->HasShield())
+	if (m_hPlayer->HasShield())
 	{
 		m_flTimeWeaponIdle = UTIL_WeaponTimeBase() + 20.0f;
 

--- a/regamedll/dlls/wpn_shared/wpn_p90.cpp
+++ b/regamedll/dlls/wpn_shared/wpn_p90.cpp
@@ -70,11 +70,11 @@ BOOL CP90::Deploy()
 
 void CP90::PrimaryAttack()
 {
-	if (!(m_pPlayer->pev->flags & FL_ONGROUND))
+	if (!(m_hPlayer->pev->flags & FL_ONGROUND))
 	{
 		P90Fire(0.3 * m_flAccuracy, 0.066, FALSE);
 	}
-	else if (m_pPlayer->pev->velocity.Length2D() > 170)
+	else if (m_hPlayer->pev->velocity.Length2D() > 170)
 	{
 		P90Fire(0.115 * m_flAccuracy, 0.066, FALSE);
 	}
@@ -107,22 +107,22 @@ void CP90::P90Fire(float flSpread, float flCycleTime, BOOL fUseAutoAim)
 
 		if (TheBots)
 		{
-			TheBots->OnEvent(EVENT_WEAPON_FIRED_ON_EMPTY, m_pPlayer);
+			TheBots->OnEvent(EVENT_WEAPON_FIRED_ON_EMPTY, m_hPlayer);
 		}
 
 		return;
 	}
 
 	m_iClip--;
-	m_pPlayer->pev->effects |= EF_MUZZLEFLASH;
-	m_pPlayer->SetAnimation(PLAYER_ATTACK1);
+	m_hPlayer->pev->effects |= EF_MUZZLEFLASH;
+	m_hPlayer->SetAnimation(PLAYER_ATTACK1);
 
-	UTIL_MakeVectors(m_pPlayer->pev->v_angle + m_pPlayer->pev->punchangle);
+	UTIL_MakeVectors(m_hPlayer->pev->v_angle + m_hPlayer->pev->punchangle);
 
-	m_pPlayer->m_iWeaponVolume = NORMAL_GUN_VOLUME;
-	m_pPlayer->m_iWeaponFlash = DIM_GUN_FLASH;
+	m_hPlayer->m_iWeaponVolume = NORMAL_GUN_VOLUME;
+	m_hPlayer->m_iWeaponFlash = DIM_GUN_FLASH;
 
-	vecSrc = m_pPlayer->GetGunPosition();
+	vecSrc = m_hPlayer->GetGunPosition();
 	vecAiming = gpGlobals->v_forward;
 
 #ifdef REGAMEDLL_API
@@ -130,7 +130,7 @@ void CP90::P90Fire(float flSpread, float flCycleTime, BOOL fUseAutoAim)
 #else
 	float flBaseDamage = P90_DAMAGE;
 #endif
-	vecDir = m_pPlayer->FireBullets3(vecSrc, vecAiming, flSpread, 8192, 1, BULLET_PLAYER_57MM, flBaseDamage, P90_RANGE_MODIFER, m_pPlayer->pev, false, m_pPlayer->random_seed);
+	vecDir = m_hPlayer->FireBullets3(vecSrc, vecAiming, flSpread, 8192, 1, BULLET_PLAYER_57MM, flBaseDamage, P90_RANGE_MODIFER, m_hPlayer->pev, false, m_hPlayer->random_seed);
 
 #ifdef CLIENT_WEAPONS
 	flag = FEV_NOTHOST;
@@ -138,27 +138,27 @@ void CP90::P90Fire(float flSpread, float flCycleTime, BOOL fUseAutoAim)
 	flag = 0;
 #endif
 
-	PLAYBACK_EVENT_FULL(flag, m_pPlayer->edict(), m_usFireP90, 0, (float *)&g_vecZero, (float *)&g_vecZero, vecDir.x, vecDir.y,
-		int(m_pPlayer->pev->punchangle.x * 100), int(m_pPlayer->pev->punchangle.y * 100), 5, FALSE);
+	PLAYBACK_EVENT_FULL(flag, m_hPlayer->edict(), m_usFireP90, 0, (float *)&g_vecZero, (float *)&g_vecZero, vecDir.x, vecDir.y,
+		int(m_hPlayer->pev->punchangle.x * 100), int(m_hPlayer->pev->punchangle.y * 100), 5, FALSE);
 
 	m_flNextPrimaryAttack = m_flNextSecondaryAttack = GetNextAttackDelay(flCycleTime);
 
-	if (!m_iClip && m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType] <= 0)
+	if (!m_iClip && m_hPlayer->m_rgAmmo[m_iPrimaryAmmoType] <= 0)
 	{
-		m_pPlayer->SetSuitUpdate("!HEV_AMO0", SUIT_SENTENCE, SUIT_REPEAT_OK);
+		m_hPlayer->SetSuitUpdate("!HEV_AMO0", SUIT_SENTENCE, SUIT_REPEAT_OK);
 	}
 
 	m_flTimeWeaponIdle = UTIL_WeaponTimeBase() + 2.0f;
 
-	if (!(m_pPlayer->pev->flags & FL_ONGROUND))
+	if (!(m_hPlayer->pev->flags & FL_ONGROUND))
 	{
 		KickBack(0.9, 0.45, 0.35, 0.04, 5.25, 3.5, 4);
 	}
-	else if (m_pPlayer->pev->velocity.Length2D() > 0)
+	else if (m_hPlayer->pev->velocity.Length2D() > 0)
 	{
 		KickBack(0.45, 0.3, 0.2, 0.0275, 4.0, 2.25, 7);
 	}
-	else if (m_pPlayer->pev->flags & FL_DUCKING)
+	else if (m_hPlayer->pev->flags & FL_DUCKING)
 	{
 		KickBack(0.275, 0.2, 0.125, 0.02, 3.0, 1.0, 9);
 	}
@@ -170,12 +170,12 @@ void CP90::P90Fire(float flSpread, float flCycleTime, BOOL fUseAutoAim)
 
 void CP90::Reload()
 {
-	if (m_pPlayer->ammo_57mm <= 0)
+	if (m_hPlayer->ammo_57mm <= 0)
 		return;
 
 	if (DefaultReload(iMaxClip(), P90_RELOAD, P90_RELOAD_TIME))
 	{
-		m_pPlayer->SetAnimation(PLAYER_RELOAD);
+		m_hPlayer->SetAnimation(PLAYER_RELOAD);
 
 		m_flAccuracy = 0.2f;
 		m_iShotsFired = 0;
@@ -185,7 +185,7 @@ void CP90::Reload()
 void CP90::WeaponIdle()
 {
 	ResetEmptySound();
-	m_pPlayer->GetAutoaimVector(AUTOAIM_10DEGREES);
+	m_hPlayer->GetAutoaimVector(AUTOAIM_10DEGREES);
 
 	if (m_flTimeWeaponIdle > UTIL_WeaponTimeBase())
 	{

--- a/regamedll/dlls/wpn_shared/wpn_scout.cpp
+++ b/regamedll/dlls/wpn_shared/wpn_scout.cpp
@@ -58,7 +58,7 @@ BOOL CSCOUT::Deploy()
 {
 	if (DefaultDeploy("models/v_scout.mdl", "models/p_scout.mdl", SCOUT_DRAW, "rifle", UseDecrement() != FALSE))
 	{
-		m_flNextPrimaryAttack = m_pPlayer->m_flNextAttack = GetNextAttackDelay(1.25);
+		m_flNextPrimaryAttack = m_hPlayer->m_flNextAttack = GetNextAttackDelay(1.25);
 		m_flNextSecondaryAttack = UTIL_WeaponTimeBase() + 1.0f;
 
 		return TRUE;
@@ -69,39 +69,39 @@ BOOL CSCOUT::Deploy()
 
 void CSCOUT::SecondaryAttack()
 {
-	switch (m_pPlayer->m_iFOV)
+	switch (m_hPlayer->m_iFOV)
 	{
-	case 90: m_pPlayer->m_iFOV = m_pPlayer->pev->fov = 40; break;
-	case 40: m_pPlayer->m_iFOV = m_pPlayer->pev->fov = 15; break;
+	case 90: m_hPlayer->m_iFOV = m_hPlayer->pev->fov = 40; break;
+	case 40: m_hPlayer->m_iFOV = m_hPlayer->pev->fov = 15; break;
 #ifdef REGAMEDLL_FIXES
 	default:
 #else
 	case 15:
 #endif
-		m_pPlayer->m_iFOV = m_pPlayer->pev->fov = 90; break;
+		m_hPlayer->m_iFOV = m_hPlayer->pev->fov = 90; break;
 	}
 
 	if (TheBots)
 	{
-		TheBots->OnEvent(EVENT_WEAPON_ZOOMED, m_pPlayer);
+		TheBots->OnEvent(EVENT_WEAPON_ZOOMED, m_hPlayer);
 	}
 
-	m_pPlayer->ResetMaxSpeed();
-	EMIT_SOUND(m_pPlayer->edict(), CHAN_ITEM, "weapons/zoom.wav", 0.2, 2.4);
+	m_hPlayer->ResetMaxSpeed();
+	EMIT_SOUND(m_hPlayer->edict(), CHAN_ITEM, "weapons/zoom.wav", 0.2, 2.4);
 	m_flNextSecondaryAttack = UTIL_WeaponTimeBase() + 0.3;
 }
 
 void CSCOUT::PrimaryAttack()
 {
-	if (!(m_pPlayer->pev->flags & FL_ONGROUND))
+	if (!(m_hPlayer->pev->flags & FL_ONGROUND))
 	{
 		SCOUTFire(0.2, 1.25, FALSE);
 	}
-	else if (m_pPlayer->pev->velocity.Length2D() > 170)
+	else if (m_hPlayer->pev->velocity.Length2D() > 170)
 	{
 		SCOUTFire(0.075, 1.25, FALSE);
 	}
-	else if (m_pPlayer->pev->flags & FL_DUCKING)
+	else if (m_hPlayer->pev->flags & FL_DUCKING)
 	{
 		SCOUTFire(0, 1.25, FALSE);
 	}
@@ -116,13 +116,13 @@ void CSCOUT::SCOUTFire(float flSpread, float flCycleTime, BOOL fUseAutoAim)
 	Vector vecAiming, vecSrc, vecDir;
 	int flag;
 
-	if (m_pPlayer->pev->fov != DEFAULT_FOV)
+	if (m_hPlayer->pev->fov != DEFAULT_FOV)
 	{
-		m_pPlayer->m_bResumeZoom = true;
-		m_pPlayer->m_iLastZoom = m_pPlayer->m_iFOV;
+		m_hPlayer->m_bResumeZoom = true;
+		m_hPlayer->m_iLastZoom = m_hPlayer->m_iFOV;
 
 		// reset a fov
-		m_pPlayer->m_iFOV = DEFAULT_FOV;
+		m_hPlayer->m_iFOV = DEFAULT_FOV;
 	}
 	else
 	{
@@ -139,22 +139,22 @@ void CSCOUT::SCOUTFire(float flSpread, float flCycleTime, BOOL fUseAutoAim)
 
 		if (TheBots)
 		{
-			TheBots->OnEvent(EVENT_WEAPON_FIRED_ON_EMPTY, m_pPlayer);
+			TheBots->OnEvent(EVENT_WEAPON_FIRED_ON_EMPTY, m_hPlayer);
 		}
 
 		return;
 	}
 
 	m_iClip--;
-	m_pPlayer->SetAnimation(PLAYER_ATTACK1);
+	m_hPlayer->SetAnimation(PLAYER_ATTACK1);
 
-	UTIL_MakeVectors(m_pPlayer->pev->v_angle + m_pPlayer->pev->punchangle);
+	UTIL_MakeVectors(m_hPlayer->pev->v_angle + m_hPlayer->pev->punchangle);
 
-	m_pPlayer->m_flEjectBrass = gpGlobals->time + 0.56f;
-	m_pPlayer->m_iWeaponVolume = BIG_EXPLOSION_VOLUME;
-	m_pPlayer->m_iWeaponFlash = NORMAL_GUN_FLASH;
+	m_hPlayer->m_flEjectBrass = gpGlobals->time + 0.56f;
+	m_hPlayer->m_iWeaponVolume = BIG_EXPLOSION_VOLUME;
+	m_hPlayer->m_iWeaponFlash = NORMAL_GUN_FLASH;
 
-	vecSrc = m_pPlayer->GetGunPosition();
+	vecSrc = m_hPlayer->GetGunPosition();
 	vecAiming = gpGlobals->v_forward;
 
 #ifdef REGAMEDLL_API
@@ -162,7 +162,7 @@ void CSCOUT::SCOUTFire(float flSpread, float flCycleTime, BOOL fUseAutoAim)
 #else
 	float flBaseDamage = SCOUT_DAMAGE;
 #endif
-	vecDir = m_pPlayer->FireBullets3(vecSrc, vecAiming, flSpread, 8192, 3, BULLET_PLAYER_762MM, flBaseDamage, SCOUT_RANGE_MODIFER, m_pPlayer->pev, true, m_pPlayer->random_seed);
+	vecDir = m_hPlayer->FireBullets3(vecSrc, vecAiming, flSpread, 8192, 3, BULLET_PLAYER_762MM, flBaseDamage, SCOUT_RANGE_MODIFER, m_hPlayer->pev, true, m_hPlayer->random_seed);
 
 #ifdef CLIENT_WEAPONS
 	flag = FEV_NOTHOST;
@@ -170,44 +170,44 @@ void CSCOUT::SCOUTFire(float flSpread, float flCycleTime, BOOL fUseAutoAim)
 	flag = 0;
 #endif
 
-	PLAYBACK_EVENT_FULL(flag, m_pPlayer->edict(), m_usFireScout, 0, (float *)&g_vecZero, (float *)&m_pPlayer->pev->angles, (vecDir.x * 1000), (vecDir.y * 1000),
-		int(m_pPlayer->pev->punchangle.x * 100), int(m_pPlayer->pev->punchangle.x * 100), FALSE, FALSE);
+	PLAYBACK_EVENT_FULL(flag, m_hPlayer->edict(), m_usFireScout, 0, (float *)&g_vecZero, (float *)&m_hPlayer->pev->angles, (vecDir.x * 1000), (vecDir.y * 1000),
+		int(m_hPlayer->pev->punchangle.x * 100), int(m_hPlayer->pev->punchangle.x * 100), FALSE, FALSE);
 
 	m_flNextPrimaryAttack = m_flNextSecondaryAttack = GetNextAttackDelay(flCycleTime);
 
-	if (!m_iClip && m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType] <= 0)
+	if (!m_iClip && m_hPlayer->m_rgAmmo[m_iPrimaryAmmoType] <= 0)
 	{
-		m_pPlayer->SetSuitUpdate("!HEV_AMO0", SUIT_SENTENCE, SUIT_REPEAT_OK);
+		m_hPlayer->SetSuitUpdate("!HEV_AMO0", SUIT_SENTENCE, SUIT_REPEAT_OK);
 	}
 
 	m_flTimeWeaponIdle = UTIL_WeaponTimeBase() + 1.8f;
-	m_pPlayer->pev->punchangle.x -= 2.0f;
+	m_hPlayer->pev->punchangle.x -= 2.0f;
 }
 
 void CSCOUT::Reload()
 {
 #ifdef REGAMEDLL_FIXES
 	// to prevent reload if not enough ammo
-	if (m_pPlayer->ammo_762nato <= 0)
+	if (m_hPlayer->ammo_762nato <= 0)
 		return;
 #endif
 
 	if (DefaultReload(iMaxClip(), SCOUT_RELOAD, SCOUT_RELOAD_TIME))
 	{
-		if (m_pPlayer->pev->fov != DEFAULT_FOV)
+		if (m_hPlayer->pev->fov != DEFAULT_FOV)
 		{
-			m_pPlayer->pev->fov = m_pPlayer->m_iFOV = 15;
+			m_hPlayer->pev->fov = m_hPlayer->m_iFOV = 15;
 			SecondaryAttack();
 		}
 
-		m_pPlayer->SetAnimation(PLAYER_RELOAD);
+		m_hPlayer->SetAnimation(PLAYER_RELOAD);
 	}
 }
 
 void CSCOUT::WeaponIdle()
 {
 	ResetEmptySound();
-	m_pPlayer->GetAutoaimVector(AUTOAIM_10DEGREES);
+	m_hPlayer->GetAutoaimVector(AUTOAIM_10DEGREES);
 
 	if (m_flTimeWeaponIdle > UTIL_WeaponTimeBase())
 	{
@@ -223,5 +223,5 @@ void CSCOUT::WeaponIdle()
 
 float CSCOUT::GetMaxSpeed()
 {
-	return (m_pPlayer->m_iFOV == DEFAULT_FOV) ? SCOUT_MAX_SPEED : SCOUT_MAX_SPEED_ZOOM;
+	return (m_hPlayer->m_iFOV == DEFAULT_FOV) ? SCOUT_MAX_SPEED : SCOUT_MAX_SPEED_ZOOM;
 }

--- a/regamedll/dlls/wpn_shared/wpn_sg550.cpp
+++ b/regamedll/dlls/wpn_shared/wpn_sg550.cpp
@@ -70,40 +70,40 @@ BOOL CSG550::Deploy()
 
 void CSG550::SecondaryAttack()
 {
-	switch (m_pPlayer->m_iFOV)
+	switch (m_hPlayer->m_iFOV)
 	{
-	case 90: m_pPlayer->m_iFOV = m_pPlayer->pev->fov = 40; break;
-	case 40: m_pPlayer->m_iFOV = m_pPlayer->pev->fov = 15; break;
+	case 90: m_hPlayer->m_iFOV = m_hPlayer->pev->fov = 40; break;
+	case 40: m_hPlayer->m_iFOV = m_hPlayer->pev->fov = 15; break;
 #ifdef REGAMEDLL_FIXES
 	default:
 #else
 	case 15:
 #endif
-		m_pPlayer->m_iFOV = m_pPlayer->pev->fov = 90; break;
+		m_hPlayer->m_iFOV = m_hPlayer->pev->fov = 90; break;
 	}
 
-	m_pPlayer->ResetMaxSpeed();
+	m_hPlayer->ResetMaxSpeed();
 
 	if (TheBots)
 	{
-		TheBots->OnEvent(EVENT_WEAPON_ZOOMED, m_pPlayer);
+		TheBots->OnEvent(EVENT_WEAPON_ZOOMED, m_hPlayer);
 	}
 
-	EMIT_SOUND(m_pPlayer->edict(), CHAN_ITEM, "weapons/zoom.wav", 0.2, 2.4);
+	EMIT_SOUND(m_hPlayer->edict(), CHAN_ITEM, "weapons/zoom.wav", 0.2, 2.4);
 	m_flNextSecondaryAttack = UTIL_WeaponTimeBase() + 0.3;
 }
 
 void CSG550::PrimaryAttack()
 {
-	if (!(m_pPlayer->pev->flags & FL_ONGROUND))
+	if (!(m_hPlayer->pev->flags & FL_ONGROUND))
 	{
 		SG550Fire(0.45 * (1 - m_flAccuracy), 0.25, FALSE);
 	}
-	else if (m_pPlayer->pev->velocity.Length2D() > 0)
+	else if (m_hPlayer->pev->velocity.Length2D() > 0)
 	{
 		SG550Fire(0.15, 0.25, FALSE);
 	}
-	else if (m_pPlayer->pev->flags & FL_DUCKING)
+	else if (m_hPlayer->pev->flags & FL_DUCKING)
 	{
 		SG550Fire(0.04 * (1 - m_flAccuracy), 0.25, FALSE);
 	}
@@ -118,7 +118,7 @@ void CSG550::SG550Fire(float flSpread, float flCycleTime, BOOL fUseAutoAim)
 	Vector vecAiming, vecSrc, vecDir;
 	int flag;
 
-	if (m_pPlayer->pev->fov == DEFAULT_FOV)
+	if (m_hPlayer->pev->fov == DEFAULT_FOV)
 	{
 		flSpread += 0.025f;
 	}
@@ -145,22 +145,22 @@ void CSG550::SG550Fire(float flSpread, float flCycleTime, BOOL fUseAutoAim)
 
 		if (TheBots)
 		{
-			TheBots->OnEvent(EVENT_WEAPON_FIRED_ON_EMPTY, m_pPlayer);
+			TheBots->OnEvent(EVENT_WEAPON_FIRED_ON_EMPTY, m_hPlayer);
 		}
 
 		return;
 	}
 
 	m_iClip--;
-	m_pPlayer->pev->effects |= EF_MUZZLEFLASH;
-	m_pPlayer->SetAnimation(PLAYER_ATTACK1);
+	m_hPlayer->pev->effects |= EF_MUZZLEFLASH;
+	m_hPlayer->SetAnimation(PLAYER_ATTACK1);
 
-	UTIL_MakeVectors(m_pPlayer->pev->v_angle + m_pPlayer->pev->punchangle);
+	UTIL_MakeVectors(m_hPlayer->pev->v_angle + m_hPlayer->pev->punchangle);
 
-	m_pPlayer->m_iWeaponVolume = BIG_EXPLOSION_VOLUME;
-	m_pPlayer->m_iWeaponFlash = NORMAL_GUN_FLASH;
+	m_hPlayer->m_iWeaponVolume = BIG_EXPLOSION_VOLUME;
+	m_hPlayer->m_iWeaponFlash = NORMAL_GUN_FLASH;
 
-	vecSrc = m_pPlayer->GetGunPosition();
+	vecSrc = m_hPlayer->GetGunPosition();
 	vecAiming = gpGlobals->v_forward;
 
 #ifdef REGAMEDLL_API
@@ -168,7 +168,7 @@ void CSG550::SG550Fire(float flSpread, float flCycleTime, BOOL fUseAutoAim)
 #else
 	float flBaseDamage = SG550_DAMAGE;
 #endif
-	vecDir = m_pPlayer->FireBullets3(vecSrc, vecAiming, flSpread, 8192, 2, BULLET_PLAYER_556MM, flBaseDamage, SG550_RANGE_MODIFER, m_pPlayer->pev, true, m_pPlayer->random_seed);
+	vecDir = m_hPlayer->FireBullets3(vecSrc, vecAiming, flSpread, 8192, 2, BULLET_PLAYER_556MM, flBaseDamage, SG550_RANGE_MODIFER, m_hPlayer->pev, true, m_hPlayer->random_seed);
 
 #ifdef CLIENT_WEAPONS
 	flag = FEV_NOTHOST;
@@ -176,34 +176,34 @@ void CSG550::SG550Fire(float flSpread, float flCycleTime, BOOL fUseAutoAim)
 	flag = 0;
 #endif
 
-	PLAYBACK_EVENT_FULL(flag, m_pPlayer->edict(), m_usFireSG550, 0, (float *)&g_vecZero, (float *)&g_vecZero, vecDir.x, vecDir.y,
-		int(m_pPlayer->pev->punchangle.x * 100), int(m_pPlayer->pev->punchangle.x * 100), 5, FALSE);
+	PLAYBACK_EVENT_FULL(flag, m_hPlayer->edict(), m_usFireSG550, 0, (float *)&g_vecZero, (float *)&g_vecZero, vecDir.x, vecDir.y,
+		int(m_hPlayer->pev->punchangle.x * 100), int(m_hPlayer->pev->punchangle.x * 100), 5, FALSE);
 
 	m_flNextPrimaryAttack = m_flNextSecondaryAttack = GetNextAttackDelay(flCycleTime);
 
-	if (!m_iClip && m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType] <= 0)
+	if (!m_iClip && m_hPlayer->m_rgAmmo[m_iPrimaryAmmoType] <= 0)
 	{
-		m_pPlayer->SetSuitUpdate("!HEV_AMO0", SUIT_SENTENCE, SUIT_REPEAT_OK);
+		m_hPlayer->SetSuitUpdate("!HEV_AMO0", SUIT_SENTENCE, SUIT_REPEAT_OK);
 	}
 
 	m_flTimeWeaponIdle = UTIL_WeaponTimeBase() + 1.8f;
 
-	m_pPlayer->pev->punchangle.x -= UTIL_SharedRandomFloat(m_pPlayer->random_seed + 4, 0.75, 1.25) + m_pPlayer->pev->punchangle.x * 0.25;
-	m_pPlayer->pev->punchangle.y += UTIL_SharedRandomFloat(m_pPlayer->random_seed + 5, -0.75, 0.75);
+	m_hPlayer->pev->punchangle.x -= UTIL_SharedRandomFloat(m_hPlayer->random_seed + 4, 0.75, 1.25) + m_hPlayer->pev->punchangle.x * 0.25;
+	m_hPlayer->pev->punchangle.y += UTIL_SharedRandomFloat(m_hPlayer->random_seed + 5, -0.75, 0.75);
 }
 
 void CSG550::Reload()
 {
-	if (m_pPlayer->ammo_556nato <= 0)
+	if (m_hPlayer->ammo_556nato <= 0)
 		return;
 
 	if (DefaultReload(iMaxClip(), SG550_RELOAD, SG550_RELOAD_TIME))
 	{
-		m_pPlayer->SetAnimation(PLAYER_RELOAD);
+		m_hPlayer->SetAnimation(PLAYER_RELOAD);
 
-		if (m_pPlayer->pev->fov != DEFAULT_FOV)
+		if (m_hPlayer->pev->fov != DEFAULT_FOV)
 		{
-			m_pPlayer->m_iFOV = m_pPlayer->pev->fov = 15;
+			m_hPlayer->m_iFOV = m_hPlayer->pev->fov = 15;
 			SecondaryAttack();
 		}
 	}
@@ -212,7 +212,7 @@ void CSG550::Reload()
 void CSG550::WeaponIdle()
 {
 	ResetEmptySound();
-	m_pPlayer->GetAutoaimVector(AUTOAIM_10DEGREES);
+	m_hPlayer->GetAutoaimVector(AUTOAIM_10DEGREES);
 
 	if (m_flTimeWeaponIdle > UTIL_WeaponTimeBase())
 	{
@@ -228,5 +228,5 @@ void CSG550::WeaponIdle()
 
 float CSG550::GetMaxSpeed()
 {
-	return (m_pPlayer->m_iFOV == DEFAULT_FOV) ? SG550_MAX_SPEED : SG550_MAX_SPEED_ZOOM;
+	return (m_hPlayer->m_iFOV == DEFAULT_FOV) ? SG550_MAX_SPEED : SG550_MAX_SPEED_ZOOM;
 }

--- a/regamedll/dlls/wpn_shared/wpn_sg552.cpp
+++ b/regamedll/dlls/wpn_shared/wpn_sg552.cpp
@@ -67,25 +67,25 @@ BOOL CSG552::Deploy()
 
 void CSG552::SecondaryAttack()
 {
-	if (m_pPlayer->m_iFOV == DEFAULT_FOV)
-		m_pPlayer->pev->fov = m_pPlayer->m_iFOV = 55;
+	if (m_hPlayer->m_iFOV == DEFAULT_FOV)
+		m_hPlayer->pev->fov = m_hPlayer->m_iFOV = 55;
 	else
-		m_pPlayer->pev->fov = m_pPlayer->m_iFOV = 90;
+		m_hPlayer->pev->fov = m_hPlayer->m_iFOV = 90;
 
 	m_flNextSecondaryAttack = UTIL_WeaponTimeBase() + 0.3f;
 }
 
 void CSG552::PrimaryAttack()
 {
-	if (!(m_pPlayer->pev->flags & FL_ONGROUND))
+	if (!(m_hPlayer->pev->flags & FL_ONGROUND))
 	{
 		SG552Fire(0.035 + (0.45 * m_flAccuracy), 0.0825, FALSE);
 	}
-	else if (m_pPlayer->pev->velocity.Length2D() > 140)
+	else if (m_hPlayer->pev->velocity.Length2D() > 140)
 	{
 		SG552Fire(0.035 + (0.075 * m_flAccuracy), 0.0825, FALSE);
 	}
-	else if (m_pPlayer->pev->fov == DEFAULT_FOV)
+	else if (m_hPlayer->pev->fov == DEFAULT_FOV)
 	{
 		SG552Fire(0.02 * m_flAccuracy, 0.0825, FALSE);
 	}
@@ -118,22 +118,22 @@ void CSG552::SG552Fire(float flSpread, float flCycleTime, BOOL fUseAutoAim)
 
 		if (TheBots)
 		{
-			TheBots->OnEvent(EVENT_WEAPON_FIRED_ON_EMPTY, m_pPlayer);
+			TheBots->OnEvent(EVENT_WEAPON_FIRED_ON_EMPTY, m_hPlayer);
 		}
 
 		return;
 	}
 
 	m_iClip--;
-	m_pPlayer->pev->effects |= EF_MUZZLEFLASH;
-	m_pPlayer->SetAnimation(PLAYER_ATTACK1);
+	m_hPlayer->pev->effects |= EF_MUZZLEFLASH;
+	m_hPlayer->SetAnimation(PLAYER_ATTACK1);
 
-	m_pPlayer->m_iWeaponVolume = NORMAL_GUN_VOLUME;
-	m_pPlayer->m_iWeaponFlash = BRIGHT_GUN_FLASH;
+	m_hPlayer->m_iWeaponVolume = NORMAL_GUN_VOLUME;
+	m_hPlayer->m_iWeaponFlash = BRIGHT_GUN_FLASH;
 
-	UTIL_MakeVectors(m_pPlayer->pev->v_angle + m_pPlayer->pev->punchangle);
+	UTIL_MakeVectors(m_hPlayer->pev->v_angle + m_hPlayer->pev->punchangle);
 
-	vecSrc = m_pPlayer->GetGunPosition();
+	vecSrc = m_hPlayer->GetGunPosition();
 	vecAiming = gpGlobals->v_forward;
 
 #ifdef REGAMEDLL_API
@@ -141,8 +141,8 @@ void CSG552::SG552Fire(float flSpread, float flCycleTime, BOOL fUseAutoAim)
 #else
 	float flBaseDamage = SG552_DAMAGE;
 #endif
-	vecDir = m_pPlayer->FireBullets3(vecSrc, vecAiming, flSpread, 8192, 2, BULLET_PLAYER_556MM,
-		flBaseDamage, SG552_RANGE_MODIFER, m_pPlayer->pev, false, m_pPlayer->random_seed);
+	vecDir = m_hPlayer->FireBullets3(vecSrc, vecAiming, flSpread, 8192, 2, BULLET_PLAYER_556MM,
+		flBaseDamage, SG552_RANGE_MODIFER, m_hPlayer->pev, false, m_hPlayer->random_seed);
 
 #ifdef CLIENT_WEAPONS
 	flag = FEV_NOTHOST;
@@ -150,27 +150,27 @@ void CSG552::SG552Fire(float flSpread, float flCycleTime, BOOL fUseAutoAim)
 	flag = 0;
 #endif
 
-	PLAYBACK_EVENT_FULL(flag, m_pPlayer->edict(), m_usFireSG552, 0, (float *)&g_vecZero, (float *)&g_vecZero, vecDir.x, vecDir.y,
-		int(m_pPlayer->pev->punchangle.x * 100), int(m_pPlayer->pev->punchangle.y * 100), 5, FALSE);
+	PLAYBACK_EVENT_FULL(flag, m_hPlayer->edict(), m_usFireSG552, 0, (float *)&g_vecZero, (float *)&g_vecZero, vecDir.x, vecDir.y,
+		int(m_hPlayer->pev->punchangle.x * 100), int(m_hPlayer->pev->punchangle.y * 100), 5, FALSE);
 
 	m_flNextPrimaryAttack = m_flNextSecondaryAttack = GetNextAttackDelay(flCycleTime);
 
-	if (!m_iClip && m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType] <= 0)
+	if (!m_iClip && m_hPlayer->m_rgAmmo[m_iPrimaryAmmoType] <= 0)
 	{
-		m_pPlayer->SetSuitUpdate("!HEV_AMO0", SUIT_SENTENCE, SUIT_REPEAT_OK);
+		m_hPlayer->SetSuitUpdate("!HEV_AMO0", SUIT_SENTENCE, SUIT_REPEAT_OK);
 	}
 
 	m_flTimeWeaponIdle = UTIL_WeaponTimeBase() + 2.0f;
 
-	if (m_pPlayer->pev->velocity.Length2D() > 0)
+	if (m_hPlayer->pev->velocity.Length2D() > 0)
 	{
 		KickBack(1.0, 0.45, 0.28, 0.04, 4.25, 2.5, 7);
 	}
-	else if (!(m_pPlayer->pev->flags & FL_ONGROUND))
+	else if (!(m_hPlayer->pev->flags & FL_ONGROUND))
 	{
 		KickBack(1.25, 0.45, 0.22, 0.18, 6.0, 4.0, 5);
 	}
-	else if (m_pPlayer->pev->flags & FL_DUCKING)
+	else if (m_hPlayer->pev->flags & FL_DUCKING)
 	{
 		KickBack(0.6, 0.35, 0.2, 0.0125, 3.7, 2.0, 10);
 	}
@@ -182,17 +182,17 @@ void CSG552::SG552Fire(float flSpread, float flCycleTime, BOOL fUseAutoAim)
 
 void CSG552::Reload()
 {
-	if (m_pPlayer->ammo_556nato <= 0)
+	if (m_hPlayer->ammo_556nato <= 0)
 		return;
 
 	if (DefaultReload(iMaxClip(), SG552_RELOAD, SG552_RELOAD_TIME))
 	{
-		if (m_pPlayer->m_iFOV != DEFAULT_FOV)
+		if (m_hPlayer->m_iFOV != DEFAULT_FOV)
 		{
 			SecondaryAttack();
 		}
 
-		m_pPlayer->SetAnimation(PLAYER_RELOAD);
+		m_hPlayer->SetAnimation(PLAYER_RELOAD);
 		m_flAccuracy = 0.2f;
 		m_iShotsFired = 0;
 		m_bDelayFire = false;
@@ -202,7 +202,7 @@ void CSG552::Reload()
 void CSG552::WeaponIdle()
 {
 	ResetEmptySound();
-	m_pPlayer->GetAutoaimVector(AUTOAIM_10DEGREES);
+	m_hPlayer->GetAutoaimVector(AUTOAIM_10DEGREES);
 
 	if (m_flTimeWeaponIdle > UTIL_WeaponTimeBase())
 	{
@@ -215,7 +215,7 @@ void CSG552::WeaponIdle()
 
 float CSG552::GetMaxSpeed()
 {
-	if (m_pPlayer->m_iFOV == DEFAULT_FOV)
+	if (m_hPlayer->m_iFOV == DEFAULT_FOV)
 		return SG552_MAX_SPEED;
 
 	return SG552_MAX_SPEED_ZOOM;

--- a/regamedll/dlls/wpn_shared/wpn_smokegrenade.cpp
+++ b/regamedll/dlls/wpn_shared/wpn_smokegrenade.cpp
@@ -62,9 +62,9 @@ BOOL CSmokeGrenade::Deploy()
 	m_flReleaseThrow = -1;
 	m_fMaxSpeed = SMOKEGRENADE_MAX_SPEED;
 
-	m_pPlayer->m_bShieldDrawn = false;
+	m_hPlayer->m_bShieldDrawn = false;
 
-	if (m_pPlayer->HasShield())
+	if (m_hPlayer->HasShield())
 		return DefaultDeploy("models/shield/v_shield_smokegrenade.mdl", "models/shield/p_shield_smokegrenade.mdl", SMOKEGRENADE_DRAW, "shieldgren", UseDecrement() != FALSE);
 	else
 		return DefaultDeploy("models/v_smokegrenade.mdl", "models/p_smokegrenade.mdl", SMOKEGRENADE_DRAW, "grenade", UseDecrement() != FALSE);
@@ -72,15 +72,15 @@ BOOL CSmokeGrenade::Deploy()
 
 void CSmokeGrenade::Holster(int skiplocal)
 {
-	m_pPlayer->m_flNextAttack = UTIL_WeaponTimeBase() + 0.5f;
+	m_hPlayer->m_flNextAttack = UTIL_WeaponTimeBase() + 0.5f;
 
-	if (!m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType])
+	if (!m_hPlayer->m_rgAmmo[m_iPrimaryAmmoType])
 	{
 		// no more smokegrenades!
 		// clear the smokegrenade of bits for HUD
 #ifndef REGAMEDLL_FIXES
 		// Moved to DestroyItem()
-		m_pPlayer->pev->weapons &= ~(1 << WEAPON_SMOKEGRENADE);
+		m_hPlayer->pev->weapons &= ~(1 << WEAPON_SMOKEGRENADE);
 #endif
 
 		DestroyItem();
@@ -95,7 +95,7 @@ void CSmokeGrenade::PrimaryAttack()
 	if (m_iWeaponState & WPNSTATE_SHIELD_DRAWN)
 		return;
 
-	if (!m_flStartThrow && m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType] > 0)
+	if (!m_flStartThrow && m_hPlayer->m_rgAmmo[m_iPrimaryAmmoType] > 0)
 	{
 		m_flReleaseThrow = 0;
 		m_flStartThrow = gpGlobals->time;
@@ -107,7 +107,7 @@ void CSmokeGrenade::PrimaryAttack()
 
 bool CSmokeGrenade::ShieldSecondaryFire(int iUpAnim, int iDownAnim)
 {
-	if (!m_pPlayer->HasShield() || m_flStartThrow > 0)
+	if (!m_hPlayer->HasShield() || m_flStartThrow > 0)
 	{
 		return false;
 	}
@@ -117,24 +117,24 @@ bool CSmokeGrenade::ShieldSecondaryFire(int iUpAnim, int iDownAnim)
 		m_iWeaponState &= ~WPNSTATE_SHIELD_DRAWN;
 		SendWeaponAnim(iDownAnim, UseDecrement() != FALSE);
 
-		Q_strcpy(m_pPlayer->m_szAnimExtention, "shieldgren");
+		Q_strcpy(m_hPlayer->m_szAnimExtention, "shieldgren");
 
 		m_fMaxSpeed = SMOKEGRENADE_MAX_SPEED;
-		m_pPlayer->m_bShieldDrawn = false;
+		m_hPlayer->m_bShieldDrawn = false;
 	}
 	else
 	{
 		m_iWeaponState |= WPNSTATE_SHIELD_DRAWN;
 		SendWeaponAnim(iUpAnim, UseDecrement() != FALSE);
 
-		Q_strcpy(m_pPlayer->m_szAnimExtention, "shielded");
+		Q_strcpy(m_hPlayer->m_szAnimExtention, "shielded");
 
 		m_fMaxSpeed = SMOKEGRENADE_MAX_SPEED_SHIELD;
-		m_pPlayer->m_bShieldDrawn = true;
+		m_hPlayer->m_bShieldDrawn = true;
 	}
 
-	m_pPlayer->UpdateShieldCrosshair((m_iWeaponState & WPNSTATE_SHIELD_DRAWN) != WPNSTATE_SHIELD_DRAWN);
-	m_pPlayer->ResetMaxSpeed();
+	m_hPlayer->UpdateShieldCrosshair((m_iWeaponState & WPNSTATE_SHIELD_DRAWN) != WPNSTATE_SHIELD_DRAWN);
+	m_hPlayer->ResetMaxSpeed();
 
 	m_flNextSecondaryAttack = UTIL_WeaponTimeBase() + 0.4f;
 	m_flNextPrimaryAttack = GetNextAttackDelay(0.4);
@@ -150,23 +150,23 @@ void CSmokeGrenade::SecondaryAttack()
 
 void CSmokeGrenade::SetPlayerShieldAnim()
 {
-	if (!m_pPlayer->HasShield())
+	if (!m_hPlayer->HasShield())
 		return;
 
 	if (m_iWeaponState & WPNSTATE_SHIELD_DRAWN)
-		Q_strcpy(m_pPlayer->m_szAnimExtention, "shield");
+		Q_strcpy(m_hPlayer->m_szAnimExtention, "shield");
 	else
-		Q_strcpy(m_pPlayer->m_szAnimExtention, "shieldgren");
+		Q_strcpy(m_hPlayer->m_szAnimExtention, "shieldgren");
 }
 
 void CSmokeGrenade::ResetPlayerShieldAnim()
 {
-	if (!m_pPlayer->HasShield())
+	if (!m_hPlayer->HasShield())
 		return;
 
 	if (m_iWeaponState & WPNSTATE_SHIELD_DRAWN)
 	{
-		Q_strcpy(m_pPlayer->m_szAnimExtention, "shieldgren");
+		Q_strcpy(m_hPlayer->m_szAnimExtention, "shieldgren");
 	}
 }
 
@@ -180,9 +180,9 @@ void CSmokeGrenade::WeaponIdle()
 
 	if (m_flStartThrow)
 	{
-		m_pPlayer->Radio("%!MRAD_FIREINHOLE", "#Fire_in_the_hole");
+		m_hPlayer->Radio("%!MRAD_FIREINHOLE", "#Fire_in_the_hole");
 
-		Vector angThrow = m_pPlayer->pev->v_angle + m_pPlayer->pev->punchangle;
+		Vector angThrow = m_hPlayer->pev->v_angle + m_hPlayer->pev->punchangle;
 
 		if (angThrow.x < 0)
 			angThrow.x = -10 + angThrow.x * ((90 - 10) / 90.0);
@@ -196,22 +196,22 @@ void CSmokeGrenade::WeaponIdle()
 
 		UTIL_MakeVectors(angThrow);
 
-		Vector vecSrc = m_pPlayer->pev->origin + m_pPlayer->pev->view_ofs + gpGlobals->v_forward * 16.0f;
-		Vector vecThrow = gpGlobals->v_forward * flVel + m_pPlayer->pev->velocity;
+		Vector vecSrc = m_hPlayer->pev->origin + m_hPlayer->pev->view_ofs + gpGlobals->v_forward * 16.0f;
+		Vector vecThrow = gpGlobals->v_forward * flVel + m_hPlayer->pev->velocity;
 
-		m_pPlayer->ThrowGrenade(this, vecSrc, vecThrow, 1.5, m_usCreateSmoke);
+		m_hPlayer->ThrowGrenade(this, vecSrc, vecThrow, 1.5, m_usCreateSmoke);
 
 		SendWeaponAnim(SMOKEGRENADE_THROW, UseDecrement() != FALSE);
 		SetPlayerShieldAnim();
 
 		// player "shoot" animation
-		m_pPlayer->SetAnimation(PLAYER_ATTACK1);
+		m_hPlayer->SetAnimation(PLAYER_ATTACK1);
 
 		m_flStartThrow = 0;
 		m_flNextPrimaryAttack = GetNextAttackDelay(0.5);
 		m_flTimeWeaponIdle = UTIL_WeaponTimeBase() + 0.75f;
 
-		if (--m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType] <= 0)
+		if (--m_hPlayer->m_rgAmmo[m_iPrimaryAmmoType] <= 0)
 		{
 			// just threw last grenade
 			// set attack times in the future, and weapon idle in the future so we can see the whole throw
@@ -227,7 +227,7 @@ void CSmokeGrenade::WeaponIdle()
 		// we've finished the throw, restart.
 		m_flStartThrow = 0;
 
-		if (m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType])
+		if (m_hPlayer->m_rgAmmo[m_iPrimaryAmmoType])
 		{
 			SendWeaponAnim(SMOKEGRENADE_DRAW, UseDecrement() != FALSE);
 		}
@@ -240,12 +240,12 @@ void CSmokeGrenade::WeaponIdle()
 		m_flTimeWeaponIdle = UTIL_WeaponTimeBase() + RANDOM_FLOAT(10, 15);
 		m_flReleaseThrow = -1;
 	}
-	else if (m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType])
+	else if (m_hPlayer->m_rgAmmo[m_iPrimaryAmmoType])
 	{
 		int iAnim;
 		float flRand = RANDOM_FLOAT(0, 1);
 
-		if (m_pPlayer->HasShield())
+		if (m_hPlayer->HasShield())
 		{
 			m_flTimeWeaponIdle = UTIL_WeaponTimeBase() + 20.0f;
 
@@ -278,5 +278,5 @@ LINK_HOOK_CLASS_CHAIN3(BOOL, CBasePlayerWeapon, CSmokeGrenade, CanDeploy)
 
 BOOL EXT_FUNC CSmokeGrenade::__API_HOOK(CanDeploy)()
 {
-	return m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType] != 0;
+	return m_hPlayer->m_rgAmmo[m_iPrimaryAmmoType] != 0;
 }

--- a/regamedll/dlls/wpn_shared/wpn_tmp.cpp
+++ b/regamedll/dlls/wpn_shared/wpn_tmp.cpp
@@ -66,7 +66,7 @@ BOOL CTMP::Deploy()
 
 void CTMP::PrimaryAttack()
 {
-	if (!(m_pPlayer->pev->flags & FL_ONGROUND))
+	if (!(m_hPlayer->pev->flags & FL_ONGROUND))
 	{
 		TMPFire(0.25 * m_flAccuracy, 0.07, FALSE);
 	}
@@ -99,20 +99,20 @@ void CTMP::TMPFire(float flSpread, float flCycleTime, BOOL fUseAutoAim)
 
 		if (TheBots)
 		{
-			TheBots->OnEvent(EVENT_WEAPON_FIRED_ON_EMPTY, m_pPlayer);
+			TheBots->OnEvent(EVENT_WEAPON_FIRED_ON_EMPTY, m_hPlayer);
 		}
 
 		return;
 	}
 
 	m_iClip--;
-	m_pPlayer->SetAnimation(PLAYER_ATTACK1);
+	m_hPlayer->SetAnimation(PLAYER_ATTACK1);
 
-	UTIL_MakeVectors(m_pPlayer->pev->v_angle + m_pPlayer->pev->punchangle);
+	UTIL_MakeVectors(m_hPlayer->pev->v_angle + m_hPlayer->pev->punchangle);
 
-	m_pPlayer->m_iWeaponVolume = NORMAL_GUN_VOLUME;
+	m_hPlayer->m_iWeaponVolume = NORMAL_GUN_VOLUME;
 
-	vecSrc = m_pPlayer->GetGunPosition();
+	vecSrc = m_hPlayer->GetGunPosition();
 	vecAiming = gpGlobals->v_forward;
 
 #ifdef REGAMEDLL_API
@@ -120,8 +120,8 @@ void CTMP::TMPFire(float flSpread, float flCycleTime, BOOL fUseAutoAim)
 #else
 	float flBaseDamage = TMP_DAMAGE;
 #endif
-	vecDir = m_pPlayer->FireBullets3(vecSrc, vecAiming, flSpread, 8192, 1, BULLET_PLAYER_9MM,
-		flBaseDamage, TMP_RANGE_MODIFER, m_pPlayer->pev, false, m_pPlayer->random_seed);
+	vecDir = m_hPlayer->FireBullets3(vecSrc, vecAiming, flSpread, 8192, 1, BULLET_PLAYER_9MM,
+		flBaseDamage, TMP_RANGE_MODIFER, m_hPlayer->pev, false, m_hPlayer->random_seed);
 
 #ifdef CLIENT_WEAPONS
 	flag = FEV_NOTHOST;
@@ -129,27 +129,27 @@ void CTMP::TMPFire(float flSpread, float flCycleTime, BOOL fUseAutoAim)
 	flag = 0;
 #endif
 
-	PLAYBACK_EVENT_FULL(flag, m_pPlayer->edict(), m_usFireTMP, 0, (float *)&g_vecZero, (float *)&g_vecZero, vecDir.x, vecDir.y,
-		int(m_pPlayer->pev->punchangle.x * 100), int(m_pPlayer->pev->punchangle.y * 100), 5, FALSE);
+	PLAYBACK_EVENT_FULL(flag, m_hPlayer->edict(), m_usFireTMP, 0, (float *)&g_vecZero, (float *)&g_vecZero, vecDir.x, vecDir.y,
+		int(m_hPlayer->pev->punchangle.x * 100), int(m_hPlayer->pev->punchangle.y * 100), 5, FALSE);
 
 	m_flNextPrimaryAttack = m_flNextSecondaryAttack = GetNextAttackDelay(flCycleTime);
 
-	if (!m_iClip && m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType] <= 0)
+	if (!m_iClip && m_hPlayer->m_rgAmmo[m_iPrimaryAmmoType] <= 0)
 	{
-		m_pPlayer->SetSuitUpdate("!HEV_AMO0", SUIT_SENTENCE, SUIT_REPEAT_OK);
+		m_hPlayer->SetSuitUpdate("!HEV_AMO0", SUIT_SENTENCE, SUIT_REPEAT_OK);
 	}
 
 	m_flTimeWeaponIdle = UTIL_WeaponTimeBase() + 2.0f;
 
-	if (!(m_pPlayer->pev->flags & FL_ONGROUND))
+	if (!(m_hPlayer->pev->flags & FL_ONGROUND))
 	{
 		KickBack(1.1, 0.5, 0.35, 0.045, 4.5, 3.5, 6);
 	}
-	else if (m_pPlayer->pev->velocity.Length2D() > 0)
+	else if (m_hPlayer->pev->velocity.Length2D() > 0)
 	{
 		KickBack(0.8, 0.4, 0.2, 0.03, 3.0, 2.5, 7);
 	}
-	else if (m_pPlayer->pev->flags & FL_DUCKING)
+	else if (m_hPlayer->pev->flags & FL_DUCKING)
 	{
 		KickBack(0.7, 0.35, 0.125, 0.025, 2.5, 2.0, 10);
 	}
@@ -163,13 +163,13 @@ void CTMP::Reload()
 {
 #ifdef REGAMEDLL_FIXES
 	// to prevent reload if not enough ammo
-	if (m_pPlayer->ammo_9mm <= 0)
+	if (m_hPlayer->ammo_9mm <= 0)
 		return;
 #endif
 
 	if (DefaultReload(iMaxClip(), TMP_RELOAD, TMP_RELOAD_TIME))
 	{
-		m_pPlayer->SetAnimation(PLAYER_RELOAD);
+		m_hPlayer->SetAnimation(PLAYER_RELOAD);
 
 		m_flAccuracy = 0.2f;
 		m_iShotsFired = 0;
@@ -179,7 +179,7 @@ void CTMP::Reload()
 void CTMP::WeaponIdle()
 {
 	ResetEmptySound();
-	m_pPlayer->GetAutoaimVector(AUTOAIM_10DEGREES);
+	m_hPlayer->GetAutoaimVector(AUTOAIM_10DEGREES);
 
 	if (m_flTimeWeaponIdle > UTIL_WeaponTimeBase())
 	{

--- a/regamedll/dlls/wpn_shared/wpn_ump45.cpp
+++ b/regamedll/dlls/wpn_shared/wpn_ump45.cpp
@@ -70,7 +70,7 @@ BOOL CUMP45::Deploy()
 
 void CUMP45::PrimaryAttack()
 {
-	if (!(m_pPlayer->pev->flags & FL_ONGROUND))
+	if (!(m_hPlayer->pev->flags & FL_ONGROUND))
 	{
 		UMP45Fire(0.24 * m_flAccuracy, 0.1, FALSE);
 	}
@@ -103,19 +103,19 @@ void CUMP45::UMP45Fire(float flSpread, float flCycleTime, BOOL fUseAutoAim)
 
 		if (TheBots)
 		{
-			TheBots->OnEvent(EVENT_WEAPON_FIRED_ON_EMPTY, m_pPlayer);
+			TheBots->OnEvent(EVENT_WEAPON_FIRED_ON_EMPTY, m_hPlayer);
 		}
 
 		return;
 	}
 
 	m_iClip--;
-	m_pPlayer->pev->effects |= EF_MUZZLEFLASH;
-	m_pPlayer->SetAnimation(PLAYER_ATTACK1);
+	m_hPlayer->pev->effects |= EF_MUZZLEFLASH;
+	m_hPlayer->SetAnimation(PLAYER_ATTACK1);
 
-	UTIL_MakeVectors(m_pPlayer->pev->v_angle + m_pPlayer->pev->punchangle);
+	UTIL_MakeVectors(m_hPlayer->pev->v_angle + m_hPlayer->pev->punchangle);
 
-	vecSrc = m_pPlayer->GetGunPosition();
+	vecSrc = m_hPlayer->GetGunPosition();
 	vecAiming = gpGlobals->v_forward;
 
 #ifdef REGAMEDLL_API
@@ -123,8 +123,8 @@ void CUMP45::UMP45Fire(float flSpread, float flCycleTime, BOOL fUseAutoAim)
 #else
 	float flBaseDamage = UMP45_DAMAGE;
 #endif
-	vecDir = m_pPlayer->FireBullets3(vecSrc, vecAiming, flSpread, 8192, 1, BULLET_PLAYER_45ACP,
-		flBaseDamage, UMP45_RANGE_MODIFER, m_pPlayer->pev, false, m_pPlayer->random_seed);
+	vecDir = m_hPlayer->FireBullets3(vecSrc, vecAiming, flSpread, 8192, 1, BULLET_PLAYER_45ACP,
+		flBaseDamage, UMP45_RANGE_MODIFER, m_hPlayer->pev, false, m_hPlayer->random_seed);
 
 #ifdef CLIENT_WEAPONS
 	flag = FEV_NOTHOST;
@@ -132,30 +132,30 @@ void CUMP45::UMP45Fire(float flSpread, float flCycleTime, BOOL fUseAutoAim)
 	flag = 0;
 #endif
 
-	PLAYBACK_EVENT_FULL(flag, m_pPlayer->edict(), m_usFireUMP45, 0, (float *)&g_vecZero, (float *)&g_vecZero, vecDir.x, vecDir.y,
-		int(m_pPlayer->pev->punchangle.x * 100), int(m_pPlayer->pev->punchangle.y * 100), FALSE, FALSE);
+	PLAYBACK_EVENT_FULL(flag, m_hPlayer->edict(), m_usFireUMP45, 0, (float *)&g_vecZero, (float *)&g_vecZero, vecDir.x, vecDir.y,
+		int(m_hPlayer->pev->punchangle.x * 100), int(m_hPlayer->pev->punchangle.y * 100), FALSE, FALSE);
 
-	m_pPlayer->m_iWeaponVolume = NORMAL_GUN_VOLUME;
-	m_pPlayer->m_iWeaponFlash = DIM_GUN_FLASH;
+	m_hPlayer->m_iWeaponVolume = NORMAL_GUN_VOLUME;
+	m_hPlayer->m_iWeaponFlash = DIM_GUN_FLASH;
 
 	m_flNextPrimaryAttack = m_flNextSecondaryAttack = GetNextAttackDelay(flCycleTime);
 
-	if (!m_iClip && m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType] <= 0)
+	if (!m_iClip && m_hPlayer->m_rgAmmo[m_iPrimaryAmmoType] <= 0)
 	{
-		m_pPlayer->SetSuitUpdate("!HEV_AMO0", SUIT_SENTENCE, SUIT_REPEAT_OK);
+		m_hPlayer->SetSuitUpdate("!HEV_AMO0", SUIT_SENTENCE, SUIT_REPEAT_OK);
 	}
 
 	m_flTimeWeaponIdle = UTIL_WeaponTimeBase() + 2.0f;
 
-	if (!(m_pPlayer->pev->flags & FL_ONGROUND))
+	if (!(m_hPlayer->pev->flags & FL_ONGROUND))
 	{
 		KickBack(0.125, 0.65, 0.55, 0.0475, 5.5, 4.0, 10);
 	}
-	else if (m_pPlayer->pev->velocity.Length2D() > 0)
+	else if (m_hPlayer->pev->velocity.Length2D() > 0)
 	{
 		KickBack(0.55, 0.3, 0.225, 0.03, 3.5, 2.5, 10);
 	}
-	else if (m_pPlayer->pev->flags & FL_DUCKING)
+	else if (m_hPlayer->pev->flags & FL_DUCKING)
 	{
 		KickBack(0.25, 0.175, 0.125, 0.02, 2.25, 1.25, 10);
 	}
@@ -167,12 +167,12 @@ void CUMP45::UMP45Fire(float flSpread, float flCycleTime, BOOL fUseAutoAim)
 
 void CUMP45::Reload()
 {
-	if (m_pPlayer->ammo_45acp <= 0)
+	if (m_hPlayer->ammo_45acp <= 0)
 		return;
 
 	if (DefaultReload(iMaxClip(), UMP45_RELOAD, UMP45_RELOAD_TIME))
 	{
-		m_pPlayer->SetAnimation(PLAYER_RELOAD);
+		m_hPlayer->SetAnimation(PLAYER_RELOAD);
 
 		m_flAccuracy = 0.0f;
 		m_iShotsFired = 0;
@@ -182,7 +182,7 @@ void CUMP45::Reload()
 void CUMP45::WeaponIdle()
 {
 	ResetEmptySound();
-	m_pPlayer->GetAutoaimVector(AUTOAIM_10DEGREES);
+	m_hPlayer->GetAutoaimVector(AUTOAIM_10DEGREES);
 
 	if (m_flTimeWeaponIdle > UTIL_WeaponTimeBase())
 	{

--- a/regamedll/dlls/wpn_shared/wpn_usp.cpp
+++ b/regamedll/dlls/wpn_shared/wpn_usp.cpp
@@ -71,9 +71,9 @@ BOOL CUSP::Deploy()
 	m_iWeaponState &= ~WPNSTATE_SHIELD_DRAWN;
 	m_flAccuracy = 0.92f;
 	m_fMaxSpeed = USP_MAX_SPEED;
-	m_pPlayer->m_bShieldDrawn = false;
+	m_hPlayer->m_bShieldDrawn = false;
 
-	if (m_pPlayer->HasShield())
+	if (m_hPlayer->HasShield())
 	{
 		m_iWeaponState &= ~WPNSTATE_USP_SILENCED;
 		return DefaultDeploy("models/shield/v_shield_usp.mdl", "models/shield/p_shield_usp.mdl", USP_SHIELD_DRAW, "shieldgun", UseDecrement());
@@ -98,14 +98,14 @@ void CUSP::SecondaryAttack()
 		m_iWeaponState &= ~WPNSTATE_USP_SILENCED;
 
 		SendWeaponAnim(USP_DETACH_SILENCER, UseDecrement() != FALSE);
-		Q_strcpy(m_pPlayer->m_szAnimExtention, "onehanded");
+		Q_strcpy(m_hPlayer->m_szAnimExtention, "onehanded");
 	}
 	else
 	{
 		m_iWeaponState |= WPNSTATE_USP_SILENCED;
 
 		SendWeaponAnim(USP_ATTACH_SILENCER, UseDecrement() != FALSE);
-		Q_strcpy(m_pPlayer->m_szAnimExtention, "onehanded");
+		Q_strcpy(m_hPlayer->m_szAnimExtention, "onehanded");
 	}
 
 	m_flNextSecondaryAttack = m_flTimeWeaponIdle = UTIL_WeaponTimeBase() + USP_ADJUST_SIL_TIME;
@@ -116,15 +116,15 @@ void CUSP::PrimaryAttack()
 {
 	if (m_iWeaponState & WPNSTATE_USP_SILENCED)
 	{
-		if (!(m_pPlayer->pev->flags & FL_ONGROUND))
+		if (!(m_hPlayer->pev->flags & FL_ONGROUND))
 		{
 			USPFire(1.3 * (1 - m_flAccuracy), 0.225, FALSE);
 		}
-		else if (m_pPlayer->pev->velocity.Length2D() > 0)
+		else if (m_hPlayer->pev->velocity.Length2D() > 0)
 		{
 			USPFire(0.25 * (1 - m_flAccuracy), 0.225, FALSE);
 		}
-		else if (m_pPlayer->pev->flags & FL_DUCKING)
+		else if (m_hPlayer->pev->flags & FL_DUCKING)
 		{
 			USPFire(0.125 * (1 - m_flAccuracy), 0.225, FALSE);
 		}
@@ -135,15 +135,15 @@ void CUSP::PrimaryAttack()
 	}
 	else
 	{
-		if (!(m_pPlayer->pev->flags & FL_ONGROUND))
+		if (!(m_hPlayer->pev->flags & FL_ONGROUND))
 		{
 			USPFire(1.2 * (1 - m_flAccuracy), 0.225, FALSE);
 		}
-		else if (m_pPlayer->pev->velocity.Length2D() > 0)
+		else if (m_hPlayer->pev->velocity.Length2D() > 0)
 		{
 			USPFire(0.225 * (1 - m_flAccuracy), 0.225, FALSE);
 		}
-		else if (m_pPlayer->pev->flags & FL_DUCKING)
+		else if (m_hPlayer->pev->flags & FL_DUCKING)
 		{
 			USPFire(0.08 * (1 - m_flAccuracy), 0.225, FALSE);
 		}
@@ -192,7 +192,7 @@ void CUSP::USPFire(float flSpread, float flCycleTime, BOOL fUseSemi)
 
 		if (TheBots)
 		{
-			TheBots->OnEvent(EVENT_WEAPON_FIRED_ON_EMPTY, m_pPlayer);
+			TheBots->OnEvent(EVENT_WEAPON_FIRED_ON_EMPTY, m_hPlayer);
 		}
 
 		return;
@@ -203,18 +203,18 @@ void CUSP::USPFire(float flSpread, float flCycleTime, BOOL fUseSemi)
 	m_iClip--;
 	SetPlayerShieldAnim();
 
-	m_pPlayer->SetAnimation(PLAYER_ATTACK1);
-	m_pPlayer->m_iWeaponVolume = BIG_EXPLOSION_VOLUME;
-	m_pPlayer->m_iWeaponFlash = DIM_GUN_FLASH;
+	m_hPlayer->SetAnimation(PLAYER_ATTACK1);
+	m_hPlayer->m_iWeaponVolume = BIG_EXPLOSION_VOLUME;
+	m_hPlayer->m_iWeaponFlash = DIM_GUN_FLASH;
 
-	UTIL_MakeVectors(m_pPlayer->pev->v_angle + m_pPlayer->pev->punchangle);
+	UTIL_MakeVectors(m_hPlayer->pev->v_angle + m_hPlayer->pev->punchangle);
 
 	if (!(m_iWeaponState & WPNSTATE_USP_SILENCED))
 	{
-		m_pPlayer->pev->effects |= EF_MUZZLEFLASH;
+		m_hPlayer->pev->effects |= EF_MUZZLEFLASH;
 	}
 
-	vecSrc = m_pPlayer->GetGunPosition();
+	vecSrc = m_hPlayer->GetGunPosition();
 	vecAiming = gpGlobals->v_forward;
 
 #ifdef REGAMEDLL_API
@@ -222,7 +222,7 @@ void CUSP::USPFire(float flSpread, float flCycleTime, BOOL fUseSemi)
 #else
 	float flBaseDamage = (m_iWeaponState & WPNSTATE_USP_SILENCED) ? USP_DAMAGE_SIL : USP_DAMAGE;
 #endif
-	vecDir = m_pPlayer->FireBullets3(vecSrc, vecAiming, flSpread, 4096, 1, BULLET_PLAYER_45ACP, flBaseDamage, USP_RANGE_MODIFER, m_pPlayer->pev, true, m_pPlayer->random_seed);
+	vecDir = m_hPlayer->FireBullets3(vecSrc, vecAiming, flSpread, 4096, 1, BULLET_PLAYER_45ACP, flBaseDamage, USP_RANGE_MODIFER, m_hPlayer->pev, true, m_hPlayer->random_seed);
 
 #ifdef CLIENT_WEAPONS
 	flag = FEV_NOTHOST;
@@ -230,26 +230,26 @@ void CUSP::USPFire(float flSpread, float flCycleTime, BOOL fUseSemi)
 	flag = 0;
 #endif // CLIENT_WEAPONS
 
-	PLAYBACK_EVENT_FULL(flag, m_pPlayer->edict(), m_usFireUSP, 0, (float *)&g_vecZero, (float *)&g_vecZero, vecDir.x, vecDir.y,
-		(int)(m_pPlayer->pev->punchangle.x * 100), 0, m_iClip == 0, (m_iWeaponState & WPNSTATE_USP_SILENCED));
+	PLAYBACK_EVENT_FULL(flag, m_hPlayer->edict(), m_usFireUSP, 0, (float *)&g_vecZero, (float *)&g_vecZero, vecDir.x, vecDir.y,
+		(int)(m_hPlayer->pev->punchangle.x * 100), 0, m_iClip == 0, (m_iWeaponState & WPNSTATE_USP_SILENCED));
 
-	if (!m_iClip && m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType] <= 0)
+	if (!m_iClip && m_hPlayer->m_rgAmmo[m_iPrimaryAmmoType] <= 0)
 	{
-		m_pPlayer->SetSuitUpdate("!HEV_AMO0", SUIT_SENTENCE, SUIT_REPEAT_OK);
+		m_hPlayer->SetSuitUpdate("!HEV_AMO0", SUIT_SENTENCE, SUIT_REPEAT_OK);
 	}
 
 	m_flTimeWeaponIdle = UTIL_WeaponTimeBase() + 2.0f;
-	m_pPlayer->pev->punchangle.x -= 2.0f;
+	m_hPlayer->pev->punchangle.x -= 2.0f;
 	ResetPlayerShieldAnim();
 }
 
 void CUSP::Reload()
 {
-	if (m_pPlayer->ammo_45acp <= 0)
+	if (m_hPlayer->ammo_45acp <= 0)
 		return;
 
 	int iAnim;
-	if (m_pPlayer->HasShield())
+	if (m_hPlayer->HasShield())
 		iAnim = USP_SHIELD_RELOAD;
 	else if (m_iWeaponState & WPNSTATE_USP_SILENCED)
 		iAnim = USP_RELOAD;
@@ -258,7 +258,7 @@ void CUSP::Reload()
 
 	if (DefaultReload(iMaxClip(), iAnim, USP_RELOAD_TIME))
 	{
-		m_pPlayer->SetAnimation(PLAYER_RELOAD);
+		m_hPlayer->SetAnimation(PLAYER_RELOAD);
 		m_flAccuracy = 0.92f;
 	}
 }
@@ -266,14 +266,14 @@ void CUSP::Reload()
 void CUSP::WeaponIdle()
 {
 	ResetEmptySound();
-	m_pPlayer->GetAutoaimVector(AUTOAIM_10DEGREES);
+	m_hPlayer->GetAutoaimVector(AUTOAIM_10DEGREES);
 
 	if (m_flTimeWeaponIdle > 0)
 	{
 		return;
 	}
 
-	if (m_pPlayer->HasShield())
+	if (m_hPlayer->HasShield())
 	{
 		m_flTimeWeaponIdle = UTIL_WeaponTimeBase() + 20.0f;
 

--- a/regamedll/dlls/wpn_shared/wpn_xm1014.cpp
+++ b/regamedll/dlls/wpn_shared/wpn_xm1014.cpp
@@ -79,7 +79,7 @@ void CXM1014::PrimaryAttack()
 
 			if (TheBots)
 			{
-				TheBots->OnEvent(EVENT_WEAPON_FIRED_ON_EMPTY, m_pPlayer);
+				TheBots->OnEvent(EVENT_WEAPON_FIRED_ON_EMPTY, m_hPlayer);
 			}
 		}
 
@@ -94,7 +94,7 @@ void CXM1014::PrimaryAttack()
 
 		if (TheBots)
 		{
-			TheBots->OnEvent(EVENT_WEAPON_FIRED_ON_EMPTY, m_pPlayer);
+			TheBots->OnEvent(EVENT_WEAPON_FIRED_ON_EMPTY, m_hPlayer);
 		}
 
 		m_flNextPrimaryAttack = GetNextAttackDelay(1);
@@ -103,17 +103,17 @@ void CXM1014::PrimaryAttack()
 		return;
 	}
 
-	m_pPlayer->m_iWeaponVolume = LOUD_GUN_VOLUME;
-	m_pPlayer->m_iWeaponFlash = BRIGHT_GUN_FLASH;
+	m_hPlayer->m_iWeaponVolume = LOUD_GUN_VOLUME;
+	m_hPlayer->m_iWeaponFlash = BRIGHT_GUN_FLASH;
 	m_iClip--;
 
-	m_pPlayer->pev->effects |= EF_MUZZLEFLASH;
+	m_hPlayer->pev->effects |= EF_MUZZLEFLASH;
 	// player "shoot" animation
-	m_pPlayer->SetAnimation(PLAYER_ATTACK1);
+	m_hPlayer->SetAnimation(PLAYER_ATTACK1);
 
-	UTIL_MakeVectors(m_pPlayer->pev->v_angle + m_pPlayer->pev->punchangle);
+	UTIL_MakeVectors(m_hPlayer->pev->v_angle + m_hPlayer->pev->punchangle);
 
-	vecSrc = m_pPlayer->GetGunPosition();
+	vecSrc = m_hPlayer->GetGunPosition();
 	vecAiming = gpGlobals->v_forward;
 
 #ifdef REGAMEDLL_API
@@ -125,9 +125,9 @@ void CXM1014::PrimaryAttack()
 	Vector vecCone(XM1014_CONE_VECTOR);
 
 #ifdef REGAMEDLL_FIXES
-	m_pPlayer->FireBuckshots(6, vecSrc, vecAiming, vecCone, 3048.0f, 0, flBaseDamage, m_pPlayer->pev);
+	m_hPlayer->FireBuckshots(6, vecSrc, vecAiming, vecCone, 3048.0f, 0, flBaseDamage, m_hPlayer->pev);
 #else
-	m_pPlayer->FireBullets(6, vecSrc, vecAiming, vecCone, 3048, BULLET_PLAYER_BUCKSHOT, 0, 0, NULL);
+	m_hPlayer->FireBullets(6, vecSrc, vecAiming, vecCone, 3048, BULLET_PLAYER_BUCKSHOT, 0, 0, NULL);
 #endif
 
 #ifdef CLIENT_WEAPONS
@@ -138,17 +138,17 @@ void CXM1014::PrimaryAttack()
 
 #ifdef REGAMEDLL_ADD
 	// HACKHACK: client-side weapon prediction fix
-	if (!(iFlags() & ITEM_FLAG_NOFIREUNDERWATER) && m_pPlayer->pev->waterlevel == 3)
+	if (!(iFlags() & ITEM_FLAG_NOFIREUNDERWATER) && m_hPlayer->pev->waterlevel == 3)
 		flag = 0;
 #endif
 
-	PLAYBACK_EVENT_FULL(flag, m_pPlayer->edict(), m_usFireXM1014, 0, (float *)&g_vecZero, (float *)&g_vecZero, m_vVecAiming.x, m_vVecAiming.y, 7,
+	PLAYBACK_EVENT_FULL(flag, m_hPlayer->edict(), m_usFireXM1014, 0, (float *)&g_vecZero, (float *)&g_vecZero, m_vVecAiming.x, m_vVecAiming.y, 7,
 		int(m_vVecAiming.x * 100), m_iClip == 0, FALSE);
 
-	if (!m_iClip && m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType] <= 0)
+	if (!m_iClip && m_hPlayer->m_rgAmmo[m_iPrimaryAmmoType] <= 0)
 	{
 		// HEV suit - indicate out of ammo condition
-		m_pPlayer->SetSuitUpdate("!HEV_AMO0", SUIT_SENTENCE, SUIT_REPEAT_OK);
+		m_hPlayer->SetSuitUpdate("!HEV_AMO0", SUIT_SENTENCE, SUIT_REPEAT_OK);
 	}
 
 #ifndef REGAMEDLL_FIXES
@@ -166,10 +166,10 @@ void CXM1014::PrimaryAttack()
 
 	m_fInSpecialReload = 0;
 
-	if (m_pPlayer->pev->flags & FL_ONGROUND)
-		m_pPlayer->pev->punchangle.x -= UTIL_SharedRandomLong(m_pPlayer->random_seed + 1, 3, 5);
+	if (m_hPlayer->pev->flags & FL_ONGROUND)
+		m_hPlayer->pev->punchangle.x -= UTIL_SharedRandomLong(m_hPlayer->random_seed + 1, 3, 5);
 	else
-		m_pPlayer->pev->punchangle.x -= UTIL_SharedRandomLong(m_pPlayer->random_seed + 1, 7, 10);
+		m_hPlayer->pev->punchangle.x -= UTIL_SharedRandomLong(m_hPlayer->random_seed + 1, 7, 10);
 }
 
 void CXM1014::Reload()
@@ -183,7 +183,7 @@ void CXM1014::Reload()
 void CXM1014::WeaponIdle()
 {
 	ResetEmptySound();
-	m_pPlayer->GetAutoaimVector(AUTOAIM_5DEGREES);
+	m_hPlayer->GetAutoaimVector(AUTOAIM_5DEGREES);
 
 #ifndef REGAMEDLL_FIXES
 	if (m_flPumpTime && m_flPumpTime < UTIL_WeaponTimeBase())
@@ -194,13 +194,13 @@ void CXM1014::WeaponIdle()
 
 	if (m_flTimeWeaponIdle < UTIL_WeaponTimeBase())
 	{
-		if (m_iClip == 0 && m_fInSpecialReload == 0 && m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType])
+		if (m_iClip == 0 && m_fInSpecialReload == 0 && m_hPlayer->m_rgAmmo[m_iPrimaryAmmoType])
 		{
 			Reload();
 		}
 		else if (m_fInSpecialReload != 0)
 		{
-			if (m_iClip != iMaxClip() && m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType])
+			if (m_iClip != iMaxClip() && m_hPlayer->m_rgAmmo[m_iPrimaryAmmoType])
 			{
 				Reload();
 			}

--- a/regamedll/game_shared/bot/bot.h
+++ b/regamedll/game_shared/bot/bot.h
@@ -326,7 +326,7 @@ inline void CBot::Walk()
 
 inline CBasePlayerWeapon *CBot::GetActiveWeapon() const
 {
-	return static_cast<CBasePlayerWeapon *>(m_pActiveItem);
+	return m_hActiveItem.Get<CBasePlayerWeapon>();
 }
 
 inline bool CBot::IsActiveWeaponCanShootUnderwater() const

--- a/regamedll/game_shared/bot/bot_util.cpp
+++ b/regamedll/game_shared/bot/bot_util.cpp
@@ -669,10 +669,10 @@ bool IsGameEventAudible(GameEventType event, CBaseEntity *pEntity, CBaseEntity *
 	// TODO: Use actual volume, account for silencers, etc.
 	case EVENT_WEAPON_FIRED:
 	{
-		if (!pPlayer->m_pActiveItem)
+		if (!pPlayer->m_hActiveItem)
 			return false;
 
-		switch (pPlayer->m_pActiveItem->m_iId)
+		switch (pPlayer->m_hActiveItem->m_iId)
 		{
 		// silent "firing"
 		case WEAPON_HEGRENADE:
@@ -689,8 +689,8 @@ bool IsGameEventAudible(GameEventType event, CBaseEntity *pEntity, CBaseEntity *
 		// M4A1 - check for silencer
 		case WEAPON_M4A1:
 		{
-			CBasePlayerWeapon *pWeapon = static_cast<CBasePlayerWeapon *>(pPlayer->m_pActiveItem);
-			if (pWeapon->m_iWeaponState & WPNSTATE_M4A1_SILENCED)
+			CBasePlayerWeapon *pWeapon = pPlayer->m_hActiveItem.Get<CBasePlayerWeapon>();
+			if (pWeapon && pWeapon->m_iWeaponState & WPNSTATE_M4A1_SILENCED)
 				*range = ShortRange;
 			else
 				*range = NormalRange;
@@ -699,8 +699,8 @@ bool IsGameEventAudible(GameEventType event, CBaseEntity *pEntity, CBaseEntity *
 		// USP - check for silencer
 		case WEAPON_USP:
 		{
-			CBasePlayerWeapon *pWeapon = static_cast<CBasePlayerWeapon *>(pPlayer->m_pActiveItem);
-			if (pWeapon->m_iWeaponState & WPNSTATE_USP_SILENCED)
+			CBasePlayerWeapon *pWeapon = pPlayer->m_hActiveItem.Get<CBasePlayerWeapon>();
+			if (pWeapon && pWeapon->m_iWeaponState & WPNSTATE_USP_SILENCED)
 				*range = ShortRange;
 			else
 				*range = NormalRange;


### PR DESCRIPTION
Hi,
I was playing counter strike 1.6 from 2005 and when have FreezeTime Terrorists can do double ducks when they on rampa
and move towards the long (In Speed Like 200 - sv_maxspeed 200)
and now when I play with all updates to CS, ReHLDS, ReGameDLL and more. I do double duck and I have 2 problems.

first, Ducks Rampa Bug - dont work when player use fps_override 1
second, this bug is too 'slowly' ducks and I want to fastest the ducks maybe cvar - sv_maxspeed_freezetime_ducks

will help to cs community, maybe another servers want to close double ducks bug.. so they will use sv_maxspeed_freezetime_ducks 0