### PR TITLE
Getting rid of g_pevLastInflictor global var as a pseudo param for CBasePlayer::Killed

### DIFF
--- a/regamedll/dlls/basemonster.cpp
+++ b/regamedll/dlls/basemonster.cpp
@@ -460,25 +460,13 @@ BOOL CBaseMonster::TakeDamage(entvars_t *pevInflictor, entvars_t *pevAttacker, f
 
 	if (pev->health <= 0.0f)
 	{
-#ifndef REGAMEDLL_FIXES
-		// NOTE: use victim's dmg_inflictor entvar instead
-		// g_pevLastInflictor is only used on CBasePlayer::Killed
-		// 	so killing non player entities have no issue with this exclusion
-		// it also provides a way to call Killed without calling
-		// 	TakeDamage for updating this dumb var, and be able to 
-		// 	alter dmg_inflictor entvar instead (which has almost no use)
-		g_pevLastInflictor = pevInflictor;
-#endif
 		if (bitsDamageType & DMG_ALWAYSGIB)
 			Killed(pevAttacker, GIB_ALWAYS);
-
 		else if (bitsDamageType & DMG_NEVERGIB)
 			Killed(pevAttacker, GIB_NEVER);
 		else
 			Killed(pevAttacker, GIB_NORMAL);
-#ifndef REGAMEDLL_FIXES
-		g_pevLastInflictor = nullptr;
-#endif
+
 		return FALSE;
 	}
 	if ((pev->flags & FL_MONSTER) && !FNullEnt(pevAttacker))

--- a/regamedll/dlls/basemonster.cpp
+++ b/regamedll/dlls/basemonster.cpp
@@ -466,7 +466,7 @@ BOOL CBaseMonster::TakeDamage(entvars_t *pevInflictor, entvars_t *pevAttacker, f
 		// 	so killing non player entities have no issue with this exclusion
 		// it also provides a way to call Killed without calling
 		// 	TakeDamage for updating this dumb var, and be able to 
-		// 	alter dmg_inflictor entvar instead (which has no use)
+		// 	alter dmg_inflictor entvar instead (which has almost no use)
 		g_pevLastInflictor = pevInflictor;
 #endif
 		if (bitsDamageType & DMG_ALWAYSGIB)

--- a/regamedll/dlls/multiplay_gamerules.cpp
+++ b/regamedll/dlls/multiplay_gamerules.cpp
@@ -5147,6 +5147,9 @@ void CHalfLifeMultiplay::ChangePlayerTeam(CBasePlayer *pPlayer, const char *pTea
 
 			// have the player kill themself
 			pPlayer->pev->health = 0;
+#ifdef REGAMEDLL_FIXES
+			pPlayer->pev->dmg_inflictor = nullptr;
+#endif
 			pPlayer->Killed(pPlayer->pev, bGib ? GIB_ALWAYS : GIB_NEVER);
 
 			// add 1 to frags to balance out the 1 subtracted for killing yourself

--- a/regamedll/dlls/player.cpp
+++ b/regamedll/dlls/player.cpp
@@ -5465,6 +5465,7 @@ void EXT_FUNC CBasePlayer::__API_HOOK(Spawn)()
 	pev->dmg_save = 0;
 
 #ifdef REGAMEDLL_FIXES
+	pev->dmg_inflictor = nullptr;
 	pev->watertype = CONTENTS_EMPTY;
 	pev->waterlevel = 0;
 	pev->basevelocity = g_vecZero;	// pushed by trigger_push
@@ -10341,6 +10342,9 @@ bool CBasePlayer::Kill()
 
 	// have the player kill himself
 	pev->health = 0.0f;
+#ifdef REGAMEDLL_FIXES
+	pev->dmg_inflictor = nullptr;
+#endif
 	Killed(pev, GIB_NEVER);
 
 	if (CSGameRules()->m_pVIP == this)

--- a/regamedll/dlls/player.cpp
+++ b/regamedll/dlls/player.cpp
@@ -7358,10 +7358,6 @@ void EXT_FUNC CBasePlayer::__API_HOOK(UpdateClientData)()
 			{
 				damageOrigin = pEntity->Center();
 			}
-
-#ifdef REGAMEDLL_FIXES
-			pev->dmg_inflictor = nullptr;
-#endif
 		}
 
 		// only send down damage type that have hud art

--- a/regamedll/dlls/player.cpp
+++ b/regamedll/dlls/player.cpp
@@ -82,10 +82,6 @@ const char *CDeadHEV::m_szPoses[] =
 	"deadtable"
 };
 
-#ifndef REGAMEDLL_FIXES
-entvars_t *g_pevLastInflictor;
-#endif 
-
 LINK_ENTITY_TO_CLASS(player, CBasePlayer, CCSPlayer)
 
 #ifdef REGAMEDLL_API
@@ -2123,7 +2119,7 @@ void EXT_FUNC CBasePlayer::__API_HOOK(Killed)(entvars_t *pevAttacker, int iGib)
 					if (IsBot() && IsBlind()) // dystopm: shouldn't be !IsBot() ?
 						wasBlind = true;
 
-					TheCareerTasks->HandleEnemyKill(wasBlind, GetWeaponName(g_pevLastInflictor, pevAttacker), m_bHeadshotKilled, killerHasShield, pAttacker, this); // last 2 param swapped to match function definition
+					TheCareerTasks->HandleEnemyKill(wasBlind, GetWeaponName(VARS(pev->dmg_inflictor), pevAttacker), m_bHeadshotKilled, killerHasShield, pAttacker, this); // last 2 param swapped to match function definition
 				}
 			}
 #endif
@@ -2154,13 +2150,7 @@ void EXT_FUNC CBasePlayer::__API_HOOK(Killed)(entvars_t *pevAttacker, int iGib)
 				{
 					if (TheCareerTasks)
 					{
-						TheCareerTasks->HandleEnemyKill(wasBlind, 
-#ifdef REGAMEDLL_FIXES
-							GetWeaponName(VARS(pev->dmg_inflictor), pevAttacker), 
-#else
-							GetWeaponName(g_pevLastInflictor, pevAttacker), 
-#endif
-							m_bHeadshotKilled, killerHasShield, this, pPlayer);
+						TheCareerTasks->HandleEnemyKill(wasBlind, GetWeaponName(VARS(pev->dmg_inflictor), pevAttacker), m_bHeadshotKilled, killerHasShield, this, pPlayer);
 					}
 				}
 			}
@@ -2170,13 +2160,7 @@ void EXT_FUNC CBasePlayer::__API_HOOK(Killed)(entvars_t *pevAttacker, int iGib)
 
 	if (!m_bKilledByBomb)
 	{
-		g_pGameRules->PlayerKilled(this, pevAttacker, 
-#ifdef REGAMEDLL_FIXES
-			VARS(pev->dmg_inflictor)
-#else
-			g_pevLastInflictor
-#endif
-			);
+		g_pGameRules->PlayerKilled(this, pevAttacker, VARS(pev->dmg_inflictor));
 	}
 
 	MESSAGE_BEGIN(MSG_ONE, gmsgNVGToggle, nullptr, pev);

--- a/regamedll/dlls/player.cpp
+++ b/regamedll/dlls/player.cpp
@@ -82,7 +82,9 @@ const char *CDeadHEV::m_szPoses[] =
 	"deadtable"
 };
 
+#ifndef REGAMEDLL_FIXES
 entvars_t *g_pevLastInflictor;
+#endif 
 
 LINK_ENTITY_TO_CLASS(player, CBasePlayer, CCSPlayer)
 
@@ -2072,7 +2074,13 @@ void EXT_FUNC CBasePlayer::__API_HOOK(Killed)(entvars_t *pevAttacker, int iGib)
 				{
 					if (TheCareerTasks)
 					{
-						TheCareerTasks->HandleEnemyKill(wasBlind, GetWeaponName(g_pevLastInflictor, pevAttacker), m_bHeadshotKilled, killerHasShield, this, pPlayer);
+						TheCareerTasks->HandleEnemyKill(wasBlind, 
+#ifdef REGAMEDLL_FIXES
+							GetWeaponName(VARS(pev->dmg_inflictor), pevAttacker), 
+#else
+							GetWeaponName(g_pevLastInflictor, pevAttacker), 
+#endif
+							m_bHeadshotKilled, killerHasShield, this, pPlayer);
 					}
 				}
 			}
@@ -2081,7 +2089,13 @@ void EXT_FUNC CBasePlayer::__API_HOOK(Killed)(entvars_t *pevAttacker, int iGib)
 
 	if (!m_bKilledByBomb)
 	{
-		g_pGameRules->PlayerKilled(this, pevAttacker, g_pevLastInflictor);
+		g_pGameRules->PlayerKilled(this, pevAttacker, 
+#ifdef REGAMEDLL_FIXES
+			VARS(pev->dmg_inflictor)
+#else
+			g_pevLastInflictor
+#endif
+			);
 	}
 
 	MESSAGE_BEGIN(MSG_ONE, gmsgNVGToggle, nullptr, pev);

--- a/regamedll/dlls/player.cpp
+++ b/regamedll/dlls/player.cpp
@@ -7358,6 +7358,10 @@ void EXT_FUNC CBasePlayer::__API_HOOK(UpdateClientData)()
 			{
 				damageOrigin = pEntity->Center();
 			}
+
+#ifdef REGAMEDLL_FIXES
+			pev->dmg_inflictor = nullptr;
+#endif
 		}
 
 		// only send down damage type that have hud art

--- a/regamedll/dlls/player.h
+++ b/regamedll/dlls/player.h
@@ -969,9 +969,6 @@ inline CBasePlayer *UTIL_PlayerByIndexSafe(int playerIndex)
 	return pPlayer;
 }
 
-#ifndef REGAMEDLL_FIXES
-extern entvars_t *g_pevLastInflictor;
-#endif
 extern CBaseEntity *g_pLastSpawn;
 extern CBaseEntity *g_pLastCTSpawn;
 extern CBaseEntity *g_pLastTerroristSpawn;

--- a/regamedll/dlls/player.h
+++ b/regamedll/dlls/player.h
@@ -968,7 +968,9 @@ inline CBasePlayer *UTIL_PlayerByIndexSafe(int playerIndex)
 	return pPlayer;
 }
 
+#ifndef REGAMEDLL_FIXES
 extern entvars_t *g_pevLastInflictor;
+#endif
 extern CBaseEntity *g_pLastSpawn;
 extern CBaseEntity *g_pLastCTSpawn;
 extern CBaseEntity *g_pLastTerroristSpawn;


### PR DESCRIPTION
This was an old programming way in Half-Life to handle parameters, without being parameters itself passed on functions. According to HLSDK, g_pevLastInflictor declaration says: "Set in combat.cpp.  Used to pass the damage inflictor for death messages." while this can (stupidly) be a parameter in Killed() vfunc, and that we also cannot add as a parameter in Killed() since many hooks from different plugins would end broken.

If nowadays I want to rewrite TakeDamage function (totally valid I guess coming from a modding community) I wouldn't be able to because g_pevLastInflictor var cannot be changed unless I extend the API or trick a bit with memhacks.

In any case, an (almost) forgotten entvar (pev->dmg_inflictor) that is only used in players is being used correctly now, just like this global variable. Code comments tells out certain details anyway. 