### PR TITLE
Little code cleaning: g_vecAttackDir

### DIFF
--- a/regamedll/dlls/effects.cpp
+++ b/regamedll/dlls/effects.cpp
@@ -1740,7 +1740,7 @@ void CBlood::Use(CBaseEntity *pActivator, CBaseEntity *pCaller, USE_TYPE useType
 	if (pev->spawnflags & SF_BLOOD_STREAM)
 		UTIL_BloodStream(BloodPosition(pActivator), Direction(), (Color() == BLOOD_COLOR_RED) ? 70 : Color(), int(BloodAmount()));
 	else
-		UTIL_BloodDrips(BloodPosition(pActivator), Direction(), Color(), int(BloodAmount()));
+		UTIL_BloodDrips(BloodPosition(pActivator), Color(), int(BloodAmount()));
 
 	if (pev->spawnflags & SF_BLOOD_DECAL)
 	{

--- a/regamedll/dlls/effects.cpp
+++ b/regamedll/dlls/effects.cpp
@@ -1737,8 +1737,10 @@ Vector CBlood::BloodPosition(CBaseEntity *pActivator)
 
 void CBlood::Use(CBaseEntity *pActivator, CBaseEntity *pCaller, USE_TYPE useType, float value)
 {
+	const Vector direction = Direction();
+
 	if (pev->spawnflags & SF_BLOOD_STREAM)
-		UTIL_BloodStream(BloodPosition(pActivator), Direction(), (Color() == BLOOD_COLOR_RED) ? 70 : Color(), int(BloodAmount()));
+		UTIL_BloodStream(BloodPosition(pActivator), direction, (Color() == BLOOD_COLOR_RED) ? 70 : Color(), int(BloodAmount()));
 	else
 		UTIL_BloodDrips(BloodPosition(pActivator), Color(), int(BloodAmount()));
 

--- a/regamedll/dlls/player.cpp
+++ b/regamedll/dlls/player.cpp
@@ -6515,7 +6515,7 @@ void CBasePlayer::CheatImpulseCommands(int iImpulse)
 			TraceResult tr;
 			Vector dir(0, 0, 1);
 
-			UTIL_BloodDrips(pev->origin, dir, BLOOD_COLOR_RED, 2000);
+			UTIL_BloodDrips(pev->origin, BLOOD_COLOR_RED, 2000);
 
 			for (int r = 1; r < 4; r++)
 			{

--- a/regamedll/dlls/util.cpp
+++ b/regamedll/dlls/util.cpp
@@ -1056,7 +1056,7 @@ void UTIL_BloodStream(const Vector &origin, const Vector &direction, int color, 
 	MESSAGE_END();
 }
 
-void UTIL_BloodDrips(const Vector &origin, const Vector &direction, int color, int amount)
+void UTIL_BloodDrips(const Vector &origin, int color, int amount)
 {
 	if (!UTIL_ShouldShowBlood(color))
 		return;

--- a/regamedll/dlls/util.h
+++ b/regamedll/dlls/util.h
@@ -262,7 +262,7 @@ bool UTIL_IsMasterTriggered(string_t sMaster, CBaseEntity *pActivator);
 BOOL UTIL_ShouldShowBlood(int color);
 int UTIL_PointContents(const Vector &vec);
 void UTIL_BloodStream(const Vector &origin, const Vector &direction, int color, int amount);
-void UTIL_BloodDrips(const Vector &origin, const Vector &direction, int color, int amount);
+void UTIL_BloodDrips(const Vector &origin, int color, int amount);
 Vector UTIL_RandomBloodVector();
 void UTIL_BloodDecalTrace(TraceResult *pTrace, int bloodColor);
 void UTIL_DecalTrace(TraceResult *pTrace, int decalNumber);

--- a/regamedll/dlls/weapons.cpp
+++ b/regamedll/dlls/weapons.cpp
@@ -113,12 +113,9 @@ void AddMultiDamage(entvars_t *pevInflictor, CBaseEntity *pEntity, float flDamag
 void SpawnBlood(Vector vecSpot, int bloodColor, float flDamage)
 {
 	UTIL_BloodDrips(vecSpot, 
-#ifdef REGAMEDLL_FIXES
-		g_vecZero, 	// TODO: this param isn't even used, why still here?
-#else 
-		g_vecAttackDir,	// dereferencing this dumb var used mostly on singleplayer
-#endif
-		bloodColor, int(flDamage));
+		g_vecZero, // dereferencing g_vecAttackDir -> used mostly on singleplayer
+		bloodColor, 
+		int(flDamage));
 }
 
 NOXREF int DamageDecal(CBaseEntity *pEntity, int bitsDamageType)

--- a/regamedll/dlls/weapons.cpp
+++ b/regamedll/dlls/weapons.cpp
@@ -112,7 +112,13 @@ void AddMultiDamage(entvars_t *pevInflictor, CBaseEntity *pEntity, float flDamag
 
 void SpawnBlood(Vector vecSpot, int bloodColor, float flDamage)
 {
-	UTIL_BloodDrips(vecSpot, g_vecAttackDir, bloodColor, int(flDamage));
+	UTIL_BloodDrips(vecSpot, 
+#ifdef REGAMEDLL_FIXES
+		g_vecZero, 	// TODO: this param isn't even used, why still here?
+#else 
+		g_vecAttackDir,	// dereferencing this dumb var used mostly on singleplayer
+#endif
+		bloodColor, int(flDamage));
 }
 
 NOXREF int DamageDecal(CBaseEntity *pEntity, int bitsDamageType)

--- a/regamedll/dlls/weapons.cpp
+++ b/regamedll/dlls/weapons.cpp
@@ -112,10 +112,7 @@ void AddMultiDamage(entvars_t *pevInflictor, CBaseEntity *pEntity, float flDamag
 
 void SpawnBlood(Vector vecSpot, int bloodColor, float flDamage)
 {
-	UTIL_BloodDrips(vecSpot, 
-		g_vecZero, // dereferencing g_vecAttackDir -> used mostly on singleplayer
-		bloodColor, 
-		int(flDamage));
+	UTIL_BloodDrips(vecSpot, bloodColor, int(flDamage));
 }
 
 NOXREF int DamageDecal(CBaseEntity *pEntity, int bitsDamageType)


### PR DESCRIPTION
Same argument as #830 : variables used as parameters, mostly used in a old fashioned programming way and on singleplayer hlsdk branch.

Might be useless but opens mind about certain code that should be reviewed in detail.