### PR TITLE
Fix Glock and Famas undesired ammo decreasing on burst mode

### DIFF
--- a/regamedll/dlls/weapons.cpp
+++ b/regamedll/dlls/weapons.cpp
@@ -761,8 +761,9 @@ void CBasePlayerWeapon::FireRemaining(int &shotsFired, float &shootTime, BOOL bI
 	if (bIsGlock)
 	{
 		vecDir = m_pPlayer->FireBullets3(vecSrc, gpGlobals->v_forward, 0.05, 8192, 1, BULLET_PLAYER_9MM, 18, 0.9, m_pPlayer->pev, true, m_pPlayer->random_seed);
+#ifndef REGAMEDLL_FIXES
 		--m_pPlayer->ammo_9mm;
-
+#endif
 		PLAYBACK_EVENT_FULL(flag, m_pPlayer->edict(), m_usFireGlock18, 0, (float *)&g_vecZero, (float *)&g_vecZero, vecDir.x, vecDir.y,
 			int(m_pPlayer->pev->punchangle.x * 10000), int(m_pPlayer->pev->punchangle.y * 10000), m_iClip == 0, FALSE);
 	}
@@ -770,7 +771,9 @@ void CBasePlayerWeapon::FireRemaining(int &shotsFired, float &shootTime, BOOL bI
 	{
 
 		vecDir = m_pPlayer->FireBullets3(vecSrc, gpGlobals->v_forward, m_fBurstSpread, 8192, 2, BULLET_PLAYER_556MM, 30, 0.96, m_pPlayer->pev, false, m_pPlayer->random_seed);
+#ifndef REGAMEDLL_FIXES
 		--m_pPlayer->ammo_556nato;
+#endif
 
 #ifdef REGAMEDLL_ADD
 		// HACKHACK: client-side weapon prediction fix


### PR DESCRIPTION
Consider the next scenario: 

1) Get a glock with clip-bpammo of 20-1
2) Shoot 3 bullets on burst mode, leaving clip-bpammo of 17-1
3) Try to reload, won't let

You need to call TabulateAmmo to enable reload again (shoot in single mode).

There is no reason to decrease bpammo on clip decreasing action anyways.
(and there is no reason to use ammo_ members from CBaseEntity)