### PR TITLE
`CZero`: Fix broken Career Tasks

### DIFF
--- a/regamedll/dlls/career_tasks.cpp
+++ b/regamedll/dlls/career_tasks.cpp
@@ -139,7 +139,11 @@ void CCareerTask::OnWeaponKill(int weaponId, int weaponClassId, bool headshot, b
 			if (!pHostage->IsFollowingSomeone())
 				continue;
 
+#ifndef REGAMEDLL_FIXES
 			if (pHostage->m_target == pVictim)
+#else
+			if (pHostage->IsFollowing(pVictim))
+#endif
 				hostagesCount++;
 		}
 
@@ -211,11 +215,14 @@ void CCareerTask::OnEvent(GameEventType event, CBasePlayer *pVictim, CBasePlayer
 			{
 				if (!pHostage->IsAlive())
 					continue;
-
-				if (!pHostage->IsFollowingSomeone())
+#ifndef REGAMEDLL_FIXES
+				if (!pHostage->IsFollowingSomeone()) // IsFollowingSomeone = IsFollowing(NULL)
 					continue;
 
 				if (pHostage->m_target == pAttacker)
+#else
+				if (pHostage->IsFollowing(pAttacker))
+#endif
 					hostagesCount++;
 			}
 

--- a/regamedll/dlls/career_tasks.cpp
+++ b/regamedll/dlls/career_tasks.cpp
@@ -136,10 +136,10 @@ void CCareerTask::OnWeaponKill(int weaponId, int weaponClassId, bool headshot, b
 			if (!pHostage->IsAlive())
 				continue;
 
+#ifndef REGAMEDLL_FIXES
 			if (!pHostage->IsFollowingSomeone())
 				continue;
 
-#ifndef REGAMEDLL_FIXES
 			if (pHostage->m_target == pVictim)
 #else
 			if (pHostage->IsFollowing(pVictim))
@@ -216,7 +216,7 @@ void CCareerTask::OnEvent(GameEventType event, CBasePlayer *pVictim, CBasePlayer
 				if (!pHostage->IsAlive())
 					continue;
 #ifndef REGAMEDLL_FIXES
-				if (!pHostage->IsFollowingSomeone()) // IsFollowingSomeone = IsFollowing(NULL)
+				if (!pHostage->IsFollowingSomeone())
 					continue;
 
 				if (pHostage->m_target == pAttacker)

--- a/regamedll/dlls/player.cpp
+++ b/regamedll/dlls/player.cpp
@@ -2046,8 +2046,27 @@ void EXT_FUNC CBasePlayer::__API_HOOK(Killed)(entvars_t *pevAttacker, int iGib)
 			}
 
 			TheCareerTasks->HandleDeath(m_iTeam, this);
+
+#ifdef REGAMEDLL_FIXES
+			if (!m_bKilledByBomb)
+			{
+				CBasePlayer *pAttacker = CBasePlayer::Instance(pevAttacker);
+
+				if(pAttacker /*safety*/ && !pAttacker->IsBot() && pAttacker->m_iTeam != m_iTeam)
+				{
+					if (pAttacker->HasShield())
+						killerHasShield = true;
+
+					if (IsBot() && IsBlind()) // dystopm: shouldn't be !IsBot() ?
+						wasBlind = true;
+
+					TheCareerTasks->HandleEnemyKill(wasBlind, GetWeaponName(g_pevLastInflictor, pevAttacker), m_bHeadshotKilled, killerHasShield, pPlayer, this); // last 2 param swapped to match function definition
+				}
+			}
+#endif
 		}
 
+#ifndef REGAMEDLL_FIXES
 		if (!m_bKilledByBomb)
 		{
 			CBasePlayer *pAttacker = CBasePlayer::Instance(pevAttacker);
@@ -2077,6 +2096,7 @@ void EXT_FUNC CBasePlayer::__API_HOOK(Killed)(entvars_t *pevAttacker, int iGib)
 				}
 			}
 		}
+#endif
 	}
 
 	if (!m_bKilledByBomb)

--- a/regamedll/dlls/player.cpp
+++ b/regamedll/dlls/player.cpp
@@ -2060,7 +2060,7 @@ void EXT_FUNC CBasePlayer::__API_HOOK(Killed)(entvars_t *pevAttacker, int iGib)
 					if (IsBot() && IsBlind()) // dystopm: shouldn't be !IsBot() ?
 						wasBlind = true;
 
-					TheCareerTasks->HandleEnemyKill(wasBlind, GetWeaponName(g_pevLastInflictor, pevAttacker), m_bHeadshotKilled, killerHasShield, pPlayer, this); // last 2 param swapped to match function definition
+					TheCareerTasks->HandleEnemyKill(wasBlind, GetWeaponName(g_pevLastInflictor, pevAttacker), m_bHeadshotKilled, killerHasShield, pAttacker, this); // last 2 param swapped to match function definition
 				}
 			}
 #endif


### PR DESCRIPTION
Related to #835 

1. Code cleaning on `CBasePlayer::Killed` which inside calls `HandleEnemyKill` with wrong parameter order
2. Changed conditions inside `CCareerTask::OnEvent` on hostage-related events which detects leader/follower with the unused `m_target` member and changed with `IsFollowing` method.