### PR TITLE
New CVars: `mp_weapondrop` and `mp_ammodrop`

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ This means that plugins that do binary code analysis (Orpheu for example) probab
 | mp_round_restart_delay             | 5       | -   | -            | Number of seconds to delay before restarting a round after a win. |
 | mp_hegrenade_penetration           | 0       | 0   | 1            | Disable grenade damage through walls.<br/>`0` disabled<br/>`1` enabled |
 | mp_nadedrops                       | 0       | 0   | 2            | Drop a grenade after player death.<br/>`0` disabled<br/>`1` drop first available grenade<br/>`2` drop all grenades |
+| mp_weapondrop                      | 1       | 0   | 2            | Drop player weapon after death.<br/>`0` do not drop weapons after death<br/>`1` drop best/heaviest weapon after death<br/>`2` drop active weapon after death |
+| mp_ammodrop                        | 1       | 0   | 2            | Drop ammo on weapon boxes on death or manual drop.<br/>`0` always keep ammo on player<br/>`1` drop all ammo only after death<br/>`2` drop all ammo whenever player drops a weapon |
 | mp_roundrespawn_time               | 20      | 0   | -            | Player cannot respawn until next round if more than N seconds has elapsed since the beginning round.<br />`-1` means no time limit<br /> |
 | mp_auto_reload_weapons             | 0       | 0   | 1            | Automatically reload each weapon on player spawn.<br/>`0` disabled<br/>`1` enabled |
 | mp_refill_bpammo_weapons           | 0       | 0   | 2            | Refill amount of backpack ammo up to the max.<br/>`0` disabled<br/>`1` refill backpack ammo on player spawn<br/>`2` refill backpack ammo on player spawn and on the purchase of the item |

--- a/dist/game.cfg
+++ b/dist/game.cfg
@@ -78,6 +78,23 @@ mp_hegrenade_penetration "0"
 // Default value: "0"
 mp_nadedrops "0"
 
+// Drop player weapon after death
+// 0 - do not drop weapons after death
+// 1 - drop best/heaviest weapon after death (default behaviour)
+// 2 - drop active weapon after death
+// NOTE: Grenades are dropped separately depending on mp_nadedrops value
+//
+// Default value: "1"
+mp_weapondrop "1"
+
+// Drop ammo on weapon boxes on death or manual drop
+// 0 - always keep ammo on player
+// 1 - drop all ammo only after death (default behaviour)
+// 2 - drop all ammo whenever player drops a weapon (NOTE: Other weapons may remain without ammo due to same ammo sharing)
+//
+// Default value: "1"
+mp_ammodrop "1"
+
 // Player cannot respawn until next round
 // if more than N seconds has elapsed since the beginning round
 // -1 - means no time limit

--- a/regamedll/dlls/game.cpp
+++ b/regamedll/dlls/game.cpp
@@ -109,6 +109,8 @@ cvar_t maxmoney              = { "mp_maxmoney", "16000", FCVAR_SERVER, 0.0f, nul
 cvar_t round_infinite        = { "mp_round_infinite", "0", FCVAR_SERVER, 0.0f, nullptr };
 cvar_t hegrenade_penetration = { "mp_hegrenade_penetration", "0", 0, 0.0f, nullptr };
 cvar_t nadedrops             = { "mp_nadedrops", "0", 0, 0.0f, nullptr };
+cvar_t weapondrop            = { "mp_weapondrop", "1", 0, 1.0f, nullptr };
+cvar_t ammodrop              = { "mp_ammodrop", "1", 0, 1.0f, nullptr };
 cvar_t roundrespawn_time     = { "mp_roundrespawn_time", "20", 0, 20.0f, nullptr };
 cvar_t auto_reload_weapons   = { "mp_auto_reload_weapons", "0", 0, 0.0f, nullptr };
 cvar_t refill_bpammo_weapons = { "mp_refill_bpammo_weapons", "0", 0, 0.0f, nullptr }; // Useful for mods like DeathMatch, GunGame, ZombieMod etc
@@ -351,6 +353,8 @@ void EXT_FUNC GameDLLInit()
 	CVAR_REGISTER(&round_infinite);
 	CVAR_REGISTER(&hegrenade_penetration);
 	CVAR_REGISTER(&nadedrops);
+	CVAR_REGISTER(&weapondrop);
+	CVAR_REGISTER(&ammodrop);
 	CVAR_REGISTER(&roundrespawn_time);
 	CVAR_REGISTER(&auto_reload_weapons);
 	CVAR_REGISTER(&refill_bpammo_weapons);

--- a/regamedll/dlls/game.h
+++ b/regamedll/dlls/game.h
@@ -138,6 +138,8 @@ extern cvar_t maxmoney;
 extern cvar_t round_infinite;
 extern cvar_t hegrenade_penetration;
 extern cvar_t nadedrops;
+extern cvar_t weapondrop;
+extern cvar_t ammodrop;
 extern cvar_t roundrespawn_time;
 extern cvar_t auto_reload_weapons;
 extern cvar_t refill_bpammo_weapons;

--- a/regamedll/dlls/multiplay_gamerules.cpp
+++ b/regamedll/dlls/multiplay_gamerules.cpp
@@ -4332,11 +4332,27 @@ LINK_HOOK_CLASS_CUSTOM_CHAIN(int, CHalfLifeMultiplay, CSGameRules, DeadPlayerWea
 
 int EXT_FUNC CHalfLifeMultiplay::__API_HOOK(DeadPlayerWeapons)(CBasePlayer *pPlayer)
 {
+#ifdef REGAMEDLL_ADD
+	switch((int)weapondrop.value)
+	{
+		case 2: 
+			break;
+		case 1:
+			return GR_PLR_DROP_GUN_ALL; // "ALL" -> the heaviest one
+		default: 
+			return GR_PLR_DROP_GUN_NO;
+	}
+#endif
 	return GR_PLR_DROP_GUN_ACTIVE;
 }
 
 int CHalfLifeMultiplay::DeadPlayerAmmo(CBasePlayer *pPlayer)
 {
+#ifdef REGAMEDLL_ADD
+	if(ammodrop.value == 0.0f)
+		return GR_PLR_DROP_AMMO_NO;
+#endif
+
 	return GR_PLR_DROP_AMMO_ACTIVE;
 }
 

--- a/regamedll/dlls/player.cpp
+++ b/regamedll/dlls/player.cpp
@@ -1411,7 +1411,7 @@ void CBasePlayer::PackDeadPlayerItems()
 #ifdef REGAMEDLL_ADD 
 		if(iPackGun == GR_PLR_DROP_GUN_ACTIVE) 
 		{
-			// check if we've just already dropped our active one 
+			// check if we've just already dropped our active gun 
 			if(!bSkipPrimSec && m_pActiveItem && m_pActiveItem->CanDrop() && m_pActiveItem->iItemSlot() < KNIFE_SLOT)
 			{
 				pBestItem = m_pActiveItem;
@@ -1447,7 +1447,7 @@ void CBasePlayer::PackDeadPlayerItems()
 						if (pPlayerItem->GetItemInfo(&info)
 #endif
 #ifdef REGAMEDLL_FIXES
-							&& pPlayerItem->CanDrop()
+							&& pPlayerItem->CanDrop() // needs to be droppable
 #endif
 							)
 						{


### PR DESCRIPTION
- Added cvar `mp_weapondrop` which controls behaviour on weapon drop after death. You can choose between (0) do not drop anything after death, (1) dropping your heaviest gun (default behaviour) or (2) dropping your active weapon. It works independently of mp_nadedrops cvar (and it's also an extension of it)
- Added cvar `mp_ammodrop` which controls behaviour of ammo packing on weapon boxes drop. You can choose between (0) keep ammo on player always, (1) drop ammo on weaponbox only after death and (2) drop ammo on every weaponbox you drop either death or manual drop. 
- Fix: Ammo resetting inside `CreateWeaponBox`; ammo was not getting reset if `packAmmo` = true, no matter if weapon is not considered "exhaustible"
- Fix: `CanDrop` used inside `PackDeadPlayerItems` in case modders want to make a weapon undroppable.
- Changed usage of constants meaning: GR_PLR_DROP_GUN_* (inside `DeadPlayerWeapons`)

Related to/fixes #520 #620 #758 #821 
Tested, work as intended

PS: Cvar's names/description corrections are welcome 