### PR TITLE
Fixed crash sometimes occurring while map analyzing for zbot navigation

### DIFF
--- a/regamedll/dlls/bot/cs_bot.h
+++ b/regamedll/dlls/bot/cs_bot.h
@@ -42,9 +42,6 @@ enum
 	BOT_PROGGRESS_HIDE,     // hide status bar progress
 };
 
-extern int _navAreaCount;
-extern int _currentIndex;
-
 class CCSBot;
 class BotChatterInterface;
 
@@ -970,7 +967,6 @@ private:
 	const CNavNode *m_navNodeList;
 	CNavNode *m_currentNode;
 	NavDirType m_generationDir;
-	NavAreaList::iterator m_analyzeIter;
 
 	enum ProcessType
 	{


### PR DESCRIPTION
The iterator `m_analyzeIter` could potentially become invalid due to the possibility of `TheNavAreaList` removing elements while the analysis is ongoing.
It's recommended to test the proposed fix thoroughly before merging it