### PR TITLE
`mp_fadetoblack` fade timings now depends from `mp_dying_time` CVar

### DIFF
--- a/regamedll/dlls/API/CSPlayer.cpp
+++ b/regamedll/dlls/API/CSPlayer.cpp
@@ -58,7 +58,7 @@ EXT_FUNC bool CCSPlayer::JoinTeam(TeamName team)
 		pPlayer->StartObserver(pentSpawnSpot->v.origin, pentSpawnSpot->v.angles);
 
 		// do we have fadetoblack on? (need to fade their screen back in)
-		if (fadetoblack.value)
+		if (fadetoblack.value == FADETOBLACK_STAY)
 		{
 			UTIL_ScreenFade(pPlayer, Vector(0, 0, 0), 0.001, 0, 0, FFADE_IN);
 		}

--- a/regamedll/dlls/animating.cpp
+++ b/regamedll/dlls/animating.cpp
@@ -179,6 +179,11 @@ NOXREF int CBaseAnimating::GetBodygroup(int iGroup)
 	return ::GetBodygroup(GET_MODEL_PTR(ENT(pev)), pev, iGroup);
 }
 
+float CBaseAnimating::GetSequenceDuration() const
+{
+	return ::GetSequenceDuration(GET_MODEL_PTR(ENT(pev)), pev);
+}
+
 int CBaseAnimating::ExtractBbox(int sequence, float *mins, float *maxs)
 {
 	return ::ExtractBbox(GET_MODEL_PTR(ENT(pev)), sequence, mins, maxs);

--- a/regamedll/dlls/animation.cpp
+++ b/regamedll/dlls/animation.cpp
@@ -246,6 +246,21 @@ void GetSequenceInfo(void *pmodel, entvars_t *pev, float *pflFrameRate, float *p
 	*pflGroundSpeed = *pflGroundSpeed * pseqdesc->fps / (pseqdesc->numframes - 1);
 }
 
+float GetSequenceDuration(void *pmodel, entvars_t *pev)
+{
+	studiohdr_t *pstudiohdr = (studiohdr_t *)pmodel;
+	if (!pstudiohdr)
+		return 0;  // model ptr is not valid
+
+	if (pev->sequence < 0 || pev->sequence >= pstudiohdr->numseq)
+		return 0;  // sequence is not valid
+
+	// get current sequence time
+	mstudioseqdesc_t *pseqdesc = (mstudioseqdesc_t *)((byte *)pstudiohdr + pstudiohdr->seqindex) + int(pev->sequence);
+
+	return pseqdesc->numframes / pseqdesc->fps;
+}
+
 int GetSequenceFlags(void *pmodel, entvars_t *pev)
 {
 	studiohdr_t *pstudiohdr = (studiohdr_t *)pmodel;

--- a/regamedll/dlls/animation.h
+++ b/regamedll/dlls/animation.h
@@ -42,6 +42,7 @@ int LookupActivity(void *pmodel, entvars_t *pev, int activity);
 int LookupActivityHeaviest(void *pmodel, entvars_t *pev, int activity);
 int LookupSequence(void *pmodel, const char *label);
 void GetSequenceInfo(void *pmodel, entvars_t *pev, float *pflFrameRate, float *pflGroundSpeed);
+float GetSequenceDuration(void *pmodel, entvars_t *pev);
 int GetSequenceFlags(void *pmodel, entvars_t *pev);
 float SetController(void *pmodel, entvars_t *pev, int iController, float flValue);
 float SetBlending(void *pmodel, entvars_t *pev, int iBlender, float flValue);

--- a/regamedll/dlls/cbase.h
+++ b/regamedll/dlls/cbase.h
@@ -369,6 +369,7 @@ public:
 	float SetBoneController(int iController, float flValue = 0.0f);
 	void InitBoneControllers();
 
+	float GetSequenceDuration() const;
 	float SetBlending(int iBlender, float flValue);
 	void GetBonePosition(int iBone, Vector &origin, Vector &angles);
 	void GetAutomovement(Vector &origin, Vector &angles, float flInterval = 0.1f);

--- a/regamedll/dlls/client.cpp
+++ b/regamedll/dlls/client.cpp
@@ -1911,7 +1911,7 @@ BOOL EXT_FUNC __API_HOOK(HandleMenu_ChooseTeam)(CBasePlayer *pPlayer, int slot)
 			MESSAGE_END();
 #endif
 			// do we have fadetoblack on? (need to fade their screen back in)
-			if (fadetoblack.value)
+			if (fadetoblack.value == FADETOBLACK_STAY)
 			{
 				UTIL_ScreenFade(pPlayer, Vector(0, 0, 0), 0.001, 0, 0, FFADE_IN);
 			}

--- a/regamedll/dlls/combat.cpp
+++ b/regamedll/dlls/combat.cpp
@@ -4,7 +4,7 @@ void PlayerBlind(CBasePlayer *pPlayer, entvars_t *pevInflictor, entvars_t *pevAt
 {
 	UTIL_ScreenFade(pPlayer, color, fadeTime, fadeHold, alpha, 0);
 
-	if (!fadetoblack.value)
+	if (fadetoblack.value != FADETOBLACK_STAY)
 	{
 		for (int i = 1; i <= gpGlobals->maxClients; i++)
 		{

--- a/regamedll/dlls/multiplay_gamerules.cpp
+++ b/regamedll/dlls/multiplay_gamerules.cpp
@@ -2393,7 +2393,7 @@ void CHalfLifeMultiplay::Think()
 		MESSAGE_BEGIN(MSG_ALL, gmsgForceCam);
 			WRITE_BYTE(forcecamera.value != 0);
 			WRITE_BYTE(forcechasecam.value != 0);
-			WRITE_BYTE(fadetoblack.value != 0);
+			WRITE_BYTE(fadetoblack.value == FADETOBLACK_STAY);
 		MESSAGE_END();
 
 		m_flForceCameraValue = forcecamera.value;
@@ -3456,7 +3456,7 @@ void CHalfLifeMultiplay::InitHUD(CBasePlayer *pl)
 	MESSAGE_BEGIN(MSG_ONE, gmsgForceCam, nullptr, pl->edict());
 		WRITE_BYTE(forcecamera.value != 0);
 		WRITE_BYTE(forcechasecam.value != 0);
-		WRITE_BYTE(fadetoblack.value != 0);
+		WRITE_BYTE(fadetoblack.value == FADETOBLACK_STAY);
 	MESSAGE_END();
 
 	if (m_bGameOver)
@@ -3874,7 +3874,7 @@ BOOL EXT_FUNC CHalfLifeMultiplay::__API_HOOK(FPlayerCanRespawn)(CBasePlayer *pPl
 				{
 					// If this player just connected and fadetoblack is on, then maybe
 					// the server admin doesn't want him peeking around.
-					if (fadetoblack.value != 0.0f)
+					if (fadetoblack.value == FADETOBLACK_STAY)
 					{
 						UTIL_ScreenFade(pPlayer, Vector(0, 0, 0), 3, 3, 255, (FFADE_OUT | FFADE_STAYOUT));
 					}

--- a/regamedll/dlls/observer.cpp
+++ b/regamedll/dlls/observer.cpp
@@ -6,7 +6,7 @@ int __API_HOOK(GetForceCamera)(CBasePlayer *pObserver)
 {
 	int retVal;
 
-	if (!fadetoblack.value)
+	if (fadetoblack.value != FADETOBLACK_STAY)
 	{
 		retVal = int(CVAR_GET_FLOAT("mp_forcechasecam"));
 
@@ -51,7 +51,7 @@ void UpdateClientEffects(CBasePlayer *pObserver, int oldMode)
 {
 	bool clearProgress = false;
 	bool clearBlindness = false;
-	bool blindnessOk = (fadetoblack.value == 0);
+	bool blindnessOk = (fadetoblack.value != FADETOBLACK_STAY);
 	bool clearNightvision = false;
 
 	if (pObserver->GetObserverMode() == OBS_IN_EYE)

--- a/regamedll/dlls/observer.h
+++ b/regamedll/dlls/observer.h
@@ -32,6 +32,12 @@
 #define CAMERA_MODE_SPEC_ONLY_TEAM         1
 #define CAMERA_MODE_SPEC_ONLY_FIRST_PERSON 2
 
+enum FadeToBlack {
+	FADETOBLACK_OFF,
+	FADETOBLACK_STAY,
+	FADETOBLACK_AT_DYING,
+};
+
 int GetForceCamera(CBasePlayer *pObserver);
 void UpdateClientEffects(CBasePlayer *pObserver, int oldMode);
 

--- a/regamedll/dlls/player.cpp
+++ b/regamedll/dlls/player.cpp
@@ -2311,7 +2311,7 @@ void EXT_FUNC CBasePlayer::__API_HOOK(Killed)(entvars_t *pevAttacker, int iGib)
 	}
 	case 1:
 	{
-		UTIL_ScreenFade(this, Vector(0, 0, 0), 0.5f, flDyingDuration, 255, (FFADE_OUT | FFADE_STAYOUT));
+		UTIL_ScreenFade(this, Vector(0, 0, 0), 0.8f, flDyingDuration, 255, (FFADE_OUT | FFADE_STAYOUT));
 		break;
 	}
 	case 2:
@@ -2325,15 +2325,7 @@ void EXT_FUNC CBasePlayer::__API_HOOK(Killed)(entvars_t *pevAttacker, int iGib)
 		MESSAGE_BEGIN(MSG_ONE, gmsgADStop, nullptr, pev);
 		MESSAGE_END();
 
-		for (int i = 1; i <= gpGlobals->maxClients; i++)
-		{
-			CBasePlayer* pObserver = UTIL_PlayerByIndex(i);
-
-			if (pObserver == this || (pObserver && pObserver->IsObservingPlayer(this)))
-			{
-				UTIL_ScreenFade(pObserver, Vector(0, 0, 0), 0.5f, flDyingDuration, 255, (FFADE_OUT));
-			}
-		}
+		UTIL_ScreenFade(this, Vector(0, 0, 0), 0.8f, flDyingDuration, 255, (FFADE_OUT));
 
 		break;
 	}

--- a/regamedll/dlls/player.cpp
+++ b/regamedll/dlls/player.cpp
@@ -2309,12 +2309,12 @@ void EXT_FUNC CBasePlayer::__API_HOOK(Killed)(entvars_t *pevAttacker, int iGib)
 
 		break;
 	}
-	case 1:
+	case FADETOBLACK_STAY:
 	{
 		UTIL_ScreenFade(this, Vector(0, 0, 0), 0.8f, flDyingDuration, 255, (FFADE_OUT | FFADE_STAYOUT));
 		break;
 	}
-	case 2:
+	case FADETOBLACK_AT_DYING:
 	{
 		pev->iuser1 = OBS_CHASE_FREE;
 		pev->iuser2 = ENTINDEX(edict());

--- a/regamedll/dlls/player.h
+++ b/regamedll/dlls/player.h
@@ -453,6 +453,7 @@ public:
 	static CBasePlayer *Instance(entvars_t *pev) { return Instance(ENT(pev)); }
 	static CBasePlayer *Instance(int offset) { return Instance(ENT(offset)); }
 
+	float GetDyingAnimationDuration() const;
 	void SpawnClientSideCorpse();
 	void Observer_FindNextPlayer(bool bReverse, const char *name = nullptr);
 	CBasePlayer *Observer_IsValidTarget(int iPlayerIndex, bool bSameTeam);


### PR DESCRIPTION
- [x] Fix forcing 1-person view for players when `mp_fadetoblack = 2`;
- [x] Fix player blackout on server entry when `mp_fadetoblack = 2`;
- [x] Fix observer not being blinded when `mp_fadetoblack = 2`;
- [x] Fix `fadetoblack message` timings using new CVar `mp_dying_time`.


fix #501
fix #506