### PR TITLE
Adjust gib's velocity limit according to sv_maxvelocity

### DIFF
--- a/regamedll/dlls/gib.cpp
+++ b/regamedll/dlls/gib.cpp
@@ -5,12 +5,7 @@ LINK_ENTITY_TO_CLASS(gib, CGib, CCSGib)
 void CGib::LimitVelocity()
 {
 	float length = pev->velocity.Length();
-
-#ifdef REGAMEDLL_FIXES
-	float topspeed = CVAR_GET_FLOAT("sv_maxvelocity") * 0.75;
-#else
-	float topspeed = 1500.0f;
-#endif
+	float topspeed = CVAR_GET_FLOAT("sv_maxvelocity") * 0.75f;
 
 	// ceiling at topspeed.  The gib velocity equation is not bounded properly.  Rather than tune it
 	// in 3 separate places again, I'll just limit it here.

--- a/regamedll/dlls/gib.cpp
+++ b/regamedll/dlls/gib.cpp
@@ -7,7 +7,7 @@ void CGib::LimitVelocity()
 	float length = pev->velocity.Length();
 
 #ifdef REGAMEDLL_FIXES
-	float topspeed = Q_min(1500.0f, CVAR_GET_FLOAT("sv_maxvelocity"));
+	float topspeed = CVAR_GET_FLOAT("sv_maxvelocity") * 0.75;
 #else
 	float topspeed = 1500.0f;
 #endif
@@ -16,7 +16,7 @@ void CGib::LimitVelocity()
 	// in 3 separate places again, I'll just limit it here.
 	if (length > topspeed)
 	{
-		// This should really be sv_maxvelocity * 0.75 or something
+		// DONE: This should really be sv_maxvelocity * 0.75 or something
 		pev->velocity = pev->velocity.Normalize() * topspeed;
 	}
 }

--- a/regamedll/dlls/gib.cpp
+++ b/regamedll/dlls/gib.cpp
@@ -6,12 +6,18 @@ void CGib::LimitVelocity()
 {
 	float length = pev->velocity.Length();
 
-	// ceiling at 1500.  The gib velocity equation is not bounded properly.  Rather than tune it
+#ifdef REGAMEDLL_FIXES
+	float topspeed = Q_min(1500.0f, CVAR_GET_FLOAT("sv_maxvelocity"));
+#else
+	float topspeed = 1500.0f;
+#endif
+
+	// ceiling at topspeed.  The gib velocity equation is not bounded properly.  Rather than tune it
 	// in 3 separate places again, I'll just limit it here.
-	if (length > 1500.0)
+	if (length > topspeed)
 	{
 		// This should really be sv_maxvelocity * 0.75 or something
-		pev->velocity = pev->velocity.Normalize() * 1500;
+		pev->velocity = pev->velocity.Normalize() * topspeed;
 	}
 }
 


### PR DESCRIPTION
Adding a boundary to this magic number in (rare) cases where sv_maxvelocity < 1500, to avoid velocity bug and console messages.