### PR TITLE
Fix: Grenade weaponbox not deploying on unarmed player

### DIFF
--- a/regamedll/dlls/weapons.cpp
+++ b/regamedll/dlls/weapons.cpp
@@ -2019,7 +2019,11 @@ void CWeaponBox::Touch(CBaseEntity *pOther)
 				if (pPlayer->AddPlayerItem(pItem))
 				{
 					pItem->AttachToPlayer(pPlayer);
+#ifdef REGAMEDLL_FIXES
 					givenItem = pItem;
+#else 
+					givenItem = true;
+#endif
 				}
 
 				// unlink this weapon from the box

--- a/regamedll/dlls/weapons.cpp
+++ b/regamedll/dlls/weapons.cpp
@@ -1960,7 +1960,7 @@ void CWeaponBox::Touch(CBaseEntity *pOther)
 							if (pPlayer->AddPlayerItem(pItem))
 							{
 								pItem->AttachToPlayer(pPlayer);
-								pGivenItem = pItem;
+								givenItem = pItem;
 							}
 
 							// unlink this weapon from the box
@@ -2063,7 +2063,7 @@ void CWeaponBox::Touch(CBaseEntity *pOther)
 		// return FALSE, causing an unarmed player to not deploy any weaponbox grenade
 		if (pPlayer->m_pActiveItem != givenItem && CSGameRules()->FShouldSwitchWeapon(pPlayer, givenItem))
 		{
-			// This check is done after ammo is given 
+			// This re-check is done after ammo is given 
 			// so it ensures player properly deploys grenade from floor
 			pPlayer->SwitchWeapon(givenItem);
 		}

--- a/regamedll/dlls/weapons.cpp
+++ b/regamedll/dlls/weapons.cpp
@@ -1821,7 +1821,12 @@ void CWeaponBox::Touch(CBaseEntity *pOther)
 	pPlayer->OnTouchingWeapon(this);
 
 	bool bRemove = true;
-	bool bEmitSound = false;
+
+#ifdef REGAMEDLL_FIXES 
+	CBasePlayerItem *givenItem = nullptr;
+#else
+	bool givenItem = false;
+#endif 
 
 	// go through my weapons and try to give the usable ones to the player.
 	// it's important the the player be given ammo first, so the weapons code doesn't refuse
@@ -1955,7 +1960,7 @@ void CWeaponBox::Touch(CBaseEntity *pOther)
 							if (pPlayer->AddPlayerItem(pItem))
 							{
 								pItem->AttachToPlayer(pPlayer);
-								bEmitSound = true;
+								pGivenItem = pItem;
 							}
 
 							// unlink this weapon from the box
@@ -1992,7 +1997,7 @@ void CWeaponBox::Touch(CBaseEntity *pOther)
 						// there we will see only get one grenade. Next step - pick it up, do check again `entity_dump`,
 						// but this time we'll see them x2.
 
-						bEmitSound = true;
+						givenItem = true;
 						pPlayer->GiveNamedItem(grenadeName);
 
 						// unlink this weapon from the box
@@ -2014,7 +2019,7 @@ void CWeaponBox::Touch(CBaseEntity *pOther)
 				if (pPlayer->AddPlayerItem(pItem))
 				{
 					pItem->AttachToPlayer(pPlayer);
-					bEmitSound = true;
+					givenItem = pItem;
 				}
 
 				// unlink this weapon from the box
@@ -2048,9 +2053,21 @@ void CWeaponBox::Touch(CBaseEntity *pOther)
 		}
 	}
 
-	if (bEmitSound)
+	if (givenItem)
 	{
 		EMIT_SOUND(ENT(pPlayer->pev), CHAN_ITEM, "items/gunpickup2.wav", VOL_NORM, ATTN_NORM);
+
+#ifdef REGAMEDLL_FIXES 
+		// BUGBUG: weaponbox links gun to player, then ammo is given
+		// so FShouldSwitchWeapon's CanHolster (which checks ammo) check inside AddPlayerItem
+		// return FALSE, causing an unarmed player to not deploy any weaponbox grenade
+		if (pPlayer->m_pActiveItem != givenItem && CSGameRules()->FShouldSwitchWeapon(pPlayer, givenItem))
+		{
+			// This check is done after ammo is given 
+			// so it ensures player properly deploys grenade from floor
+			pPlayer->SwitchWeapon(givenItem);
+		}
+#endif
 	}
 
 	if (bRemove)


### PR DESCRIPTION
How to reproduce:

- Test environment cvars:
     - mp_buytime -1
     - mp_startmoney 10000
     - mp_forcerespawn 1
     - mp_ct_give_default_knife 0
     - mp_t_give_default_knife 0
     - mp_nadedrops 1
- Join CT, buy hegrenade from buymenu and then change team to T
- You'll drop your hegrenade cause of death, and respawn in a few seconds
- Having no guns (ensure you have none), you'll pickup that hegrenade and see you are not deploying it until you force it (pressing 4, or typing weapon_hegrenade in console) - may lead in a HUD bug in some cases

This commit fixes two issues:
- Grenade weaponbox not deploying on unarmed player after being picked up from ground.
- HEGrenade not being deployed when picked up from ground if you are holding a Flashbang, considering HEGrenade has more weight than Flashbang.

This issue is related to weaponbox and not armoury_entity

TODO: Weaponbox gives ammo AFTER weapon is linked to player, CanDeploy depends on ammo in exhaustible weapons, we can consider this proposal as a final solution to that; or refactor the whole weaponbox behaviour.

Related to #479 but applied in a better fashion way, with explanation