### PR TITLE
Various defuser fixes and code refactory

### DIFF
--- a/regamedll/dlls/API/CSPlayer.cpp
+++ b/regamedll/dlls/API/CSPlayer.cpp
@@ -153,15 +153,7 @@ EXT_FUNC bool CCSPlayer::RemovePlayerItemEx(const char* pszItemName, bool bRemov
 			if (!pPlayer->m_bHasDefuser)
 				return false;
 
-			pPlayer->m_bHasDefuser = false;
-			pPlayer->pev->body = 0;
-
-			MESSAGE_BEGIN(MSG_ONE, gmsgStatusIcon, nullptr, pPlayer->pev);
-				WRITE_BYTE(STATUSICON_HIDE);
-				WRITE_STRING("defuser");
-			MESSAGE_END();
-
-			pPlayer->SendItemStatus();
+			pPlayer->RemoveDefuser();
 		}
 		// item_longjump
 		else if (FStrEq(pszItemName, "longjump"))

--- a/regamedll/dlls/client.cpp
+++ b/regamedll/dlls/client.cpp
@@ -621,6 +621,9 @@ void EXT_FUNC ClientPutInServer(edict_t *pEntity)
 		return;
 	}
 
+#ifdef REGAMEDLL_FIXES
+	pPlayer->m_bHasDefuser = false;
+#endif
 	pPlayer->m_bNotKilled = true;
 	pPlayer->m_iIgnoreGlobalChat = IGNOREMSG_NONE;
 	pPlayer->m_iTeamKills = 0;

--- a/regamedll/dlls/player.cpp
+++ b/regamedll/dlls/player.cpp
@@ -3651,16 +3651,22 @@ void EXT_FUNC CBasePlayer::__API_HOOK(JoiningThink)()
 			ResetMenu();
 			m_iJoiningState = SHOWTEAMSELECT;
 
+#ifdef REGAMEDLL_FIXES
+			RemoveDefuser();
+#else 
 			MESSAGE_BEGIN(MSG_ONE, gmsgStatusIcon, nullptr, pev);
 				WRITE_BYTE(STATUSICON_HIDE);
 				WRITE_STRING("defuser");
 			MESSAGE_END();
 
 			m_bHasDefuser = false;
+#endif
 			m_fLastMovement = gpGlobals->time;
 			m_bMissionBriefing = false;
 
+#ifndef REGAMEDLL_FIXES
 			SendItemStatus();
+#endif
 			break;
 		}
 		case READINGLTEXT:

--- a/regamedll/dlls/player.cpp
+++ b/regamedll/dlls/player.cpp
@@ -1690,18 +1690,6 @@ void CBasePlayer::RemoveAllItems(BOOL removeSuit)
 	if (m_bHasDefuser)
 	{
 		RemoveDefuser();
-
-#ifndef REGAMEDLL_FIXES
-		// NOTE: moved into RemoveDefuser
-		MESSAGE_BEGIN(MSG_ONE, gmsgStatusIcon, nullptr, pev);
-			WRITE_BYTE(STATUSICON_HIDE);
-			WRITE_STRING("defuser");
-		MESSAGE_END();
-
-		SendItemStatus();
-#endif 
-
-		bKillProgBar = true;
 	}
 
 	if (m_bHasC4)
@@ -2435,30 +2423,16 @@ void EXT_FUNC CBasePlayer::__API_HOOK(Killed)(entvars_t *pevAttacker, int iGib)
 	else if (m_bHasDefuser)
 	{
 		RemoveDefuser();
-
 #ifdef REGAMEDLL_FIXES
 		SpawnDefuser(pev->origin, ENT(pev));
-
-		if (m_bIsDefusing)
-			SetProgressBarTime(0);
-
-		m_bIsDefusing = false;
 #else
 		GiveNamedItem("item_thighpack");
-
-		// NOTE: moved into RemoveDefuser
-		MESSAGE_BEGIN(MSG_ONE, gmsgStatusIcon, nullptr, pev);
-			WRITE_BYTE(STATUSICON_HIDE);
-			WRITE_STRING("defuser");
-		MESSAGE_END();
-
-		SendItemStatus();
-		SetProgressBarTime(0);
 #endif
 	}
 
 #ifndef REGAMEDLL_FIXES
-	m_bIsDefusing = false; // NOTE: moved above
+	// NOTE: moved to RemoveDefuser
+	m_bIsDefusing = false; 
 #endif
 
 	BuyZoneIcon_Clear(this);
@@ -3651,22 +3625,20 @@ void EXT_FUNC CBasePlayer::__API_HOOK(JoiningThink)()
 			ResetMenu();
 			m_iJoiningState = SHOWTEAMSELECT;
 
-#ifdef REGAMEDLL_FIXES
-			RemoveDefuser();
-#else 
-			MESSAGE_BEGIN(MSG_ONE, gmsgStatusIcon, nullptr, pev);
+#ifndef REGAMEDLL_FIXES
+			// client already clears StatusIcon on join
+			MESSAGE_BEGIN(MSG_ONE, gmsgStatusIcon, nullptr, pev); 
 				WRITE_BYTE(STATUSICON_HIDE);
 				WRITE_STRING("defuser");
 			MESSAGE_END();
 
-			m_bHasDefuser = false;
+			m_bHasDefuser = false; // unneded
 #endif
 			m_fLastMovement = gpGlobals->time;
 			m_bMissionBriefing = false;
 
-#ifndef REGAMEDLL_FIXES
-			SendItemStatus();
-#endif
+			SendItemStatus(); 
+
 			break;
 		}
 		case READINGLTEXT:
@@ -3785,25 +3757,10 @@ void EXT_FUNC CBasePlayer::__API_HOOK(Disappear)()
 	else if (m_bHasDefuser)
 	{
 		RemoveDefuser();
-
 #ifdef REGAMEDLL_FIXES
 		SpawnDefuser(pev->origin, ENT(pev));
-
-		if (m_bIsDefusing)
-			SetProgressBarTime(0);
-
-		m_bIsDefusing = false;
 #else
 		GiveNamedItem("item_thighpack");
-
-		// NOTE: moved into RemoveDefuser
-		MESSAGE_BEGIN(MSG_ONE, gmsgStatusIcon, nullptr, pev);
-			WRITE_BYTE(STATUSICON_HIDE);
-			WRITE_STRING("defuser");
-		MESSAGE_END();
-
-		SendItemStatus();
-		SetProgressBarTime(0);
 #endif
 	}
 
@@ -5707,10 +5664,7 @@ void EXT_FUNC CBasePlayer::__API_HOOK(Spawn)()
 	ReloadWeapons();
 #endif
 
-	if (m_bHasDefuser)
-		pev->body = 1;
-	else
-		pev->body = 0;
+	pev->body = m_bHasDefuser ? 1 : 0;
 
 	if (m_bMissionBriefing)
 	{
@@ -8306,18 +8260,6 @@ void CBasePlayer::__API_HOOK(SwitchTeam)()
 		RemoveDefuser();
 
 #ifndef REGAMEDLL_FIXES
-		// NOTE: moved into RemoveDefuser
-		MESSAGE_BEGIN(MSG_ONE, gmsgStatusIcon, nullptr, pev);
-			WRITE_BYTE(STATUSICON_HIDE);
-			WRITE_STRING("defuser");
-		MESSAGE_END();
-
-		SendItemStatus();
-#endif
-
-		SetProgressBarTime(0);
-
-#ifndef REGAMEDLL_FIXES
 		// NOTE: unreachable code - Vaqtincha
 		for (int i = 0; i < MAX_ITEM_TYPES; i++)
 		{
@@ -10159,14 +10101,22 @@ void CBasePlayer::RemoveDefuser()
 	m_bHasDefuser = false;
 	pev->body = 0;
 
-#ifdef REGAMEDLL_FIXES
 	MESSAGE_BEGIN(MSG_ONE, gmsgStatusIcon, nullptr, pev);
 		WRITE_BYTE(STATUSICON_HIDE);
 		WRITE_STRING("defuser");
 	MESSAGE_END();
 
 	SendItemStatus();
-#endif 
+
+#ifdef REGAMEDLL_FIXES
+	if (m_bIsDefusing)
+	{
+		SetProgressBarTime(0);
+		m_bIsDefusing = false;
+	}
+#else 
+	SetProgressBarTime(0);
+#endif
 }
 
 CItemThighPack *SpawnDefuser(const Vector &vecOrigin, edict_t *pentOwner)

--- a/regamedll/dlls/player.cpp
+++ b/regamedll/dlls/player.cpp
@@ -3626,18 +3626,18 @@ void EXT_FUNC CBasePlayer::__API_HOOK(JoiningThink)()
 			m_iJoiningState = SHOWTEAMSELECT;
 
 #ifndef REGAMEDLL_FIXES
-			// client already clears StatusIcon on join
+			// NOTE: client already clears StatusIcon on join
 			MESSAGE_BEGIN(MSG_ONE, gmsgStatusIcon, nullptr, pev); 
 				WRITE_BYTE(STATUSICON_HIDE);
 				WRITE_STRING("defuser");
 			MESSAGE_END();
 
-			m_bHasDefuser = false; // unneded
+			m_bHasDefuser = false; // set in ClientPutInServer
 #endif
 			m_fLastMovement = gpGlobals->time;
 			m_bMissionBriefing = false;
 
-			SendItemStatus(); 
+			SendItemStatus();  // NOTE: must be on UpdateClientData
 
 			break;
 		}

--- a/regamedll/dlls/player.h
+++ b/regamedll/dlls/player.h
@@ -907,6 +907,7 @@ public:
 
 CWeaponBox *CreateWeaponBox(CBasePlayerItem *pItem, CBasePlayer *pPlayerOwner, const char *modelName, Vector &origin, Vector &angles, Vector &velocity, float lifeTime, bool packAmmo);
 CWeaponBox *CreateWeaponBox_OrigFunc(CBasePlayerItem *pItem, CBasePlayer *pPlayerOwner, const char *modelName, Vector &origin, Vector &angles, Vector &velocity, float lifeTime, bool packAmmo);
+CItemThighPack *SpawnDefuser(const Vector &vecOrigin, edict_t *pentOwner);
 
 class CWShield: public CBaseEntity
 {


### PR DESCRIPTION
- Fixed `item_thighpack` entity not spawning on `CBasePlayer::Disappear` (which shares logic with `CBasePlayer::Killed`). Fixed version deleted `GiveNamedItem` (reasonably) but nobody coded the entity spawning.
- Fixed `CCSPlayer::RemovePlayerItemEx` not clearing ProgressBar HUD when removing defuser.
- Ensuring m_bIsDefusing assignation whenever defuser is removed from player.
- Defuser removal logic grouped into `CBasePlayer::RemoveDefuser`.
- Some minor logic changes and unneeded code erase.