### PR TITLE
`API`: CSPlayerWeapon integration + new members and functions

### DIFF
--- a/regamedll/CMakeLists.txt
+++ b/regamedll/CMakeLists.txt
@@ -226,6 +226,7 @@ set(GAMEDLL_SRCS
 	"dlls/API/CSEntity.cpp"
 	"dlls/API/CSPlayer.cpp"
 	"dlls/API/CSPlayerItem.cpp"
+	"dlls/API/CSPlayerWeapon.cpp"
 	"dlls/addons/item_airbox.cpp"
 	"dlls/addons/point_command.cpp"
 	"dlls/addons/trigger_random.cpp"

--- a/regamedll/dlls/API/CSPlayerWeapon.cpp
+++ b/regamedll/dlls/API/CSPlayerWeapon.cpp
@@ -26,34 +26,29 @@
 *
 */
 
-#pragma once
+#include "precompiled.h"
 
-class CBasePlayerWeapon;
-class CCSPlayerWeapon: public CCSPlayerItem
+EXT_FUNC BOOL CCSPlayerWeapon::DefaultDeploy(char *szViewModel, char *szWeaponModel, int iAnim, char *szAnimExt, int skiplocal)
 {
-public:
-	CCSPlayerWeapon() :
-		m_bHasSecondaryAttack(false),
-		m_bBlockSecondaryAttack(false)
-	{
-	}
+	return BasePlayerWeapon()->DefaultDeploy(szViewModel, szWeaponModel, iAnim, szAnimExt, skiplocal);
+}
 
-	virtual BOOL DefaultDeploy(char *szViewModel, char *szWeaponModel, int iAnim, char *szAnimExt, int skiplocal = 0);
-	virtual int DefaultReload(int iClipSize, int iAnim, float fDelay);
-	virtual bool DefaultShotgunReload(int iAnim, int iStartAnim, float fDelay, float fStartDelay, const char *pszReloadSound1 = nullptr, const char *pszReloadSound2 = nullptr);
-	virtual void KickBack(float up_base, float lateral_base, float up_modifier, float lateral_modifier, float up_max, float lateral_max, int direction_change);
-	virtual void SendWeaponAnim(int iAnim, int skiplocal = 0);
-
-	CBasePlayerWeapon *BasePlayerWeapon() const;
-
-public:
-	bool m_bHasSecondaryAttack;
-	float m_flBaseDamage;
-	bool m_bBlockSecondaryAttack;
-};
-
-// Inlines
-inline CBasePlayerWeapon *CCSPlayerWeapon::BasePlayerWeapon() const
+EXT_FUNC int CCSPlayerWeapon::DefaultReload(int iClipSize, int iAnim, float fDelay)
 {
-	return reinterpret_cast<CBasePlayerWeapon *>(this->m_pContainingEntity);
+	return BasePlayerWeapon()->DefaultReload(iClipSize, iAnim, fDelay);
+}
+
+EXT_FUNC bool CCSPlayerWeapon::DefaultShotgunReload(int iAnim, int iStartAnim, float fDelay, float fStartDelay, const char *pszReloadSound1, const char *pszReloadSound2)
+{
+	return BasePlayerWeapon()->DefaultShotgunReload(iAnim, iStartAnim, fDelay, fStartDelay, pszReloadSound1, pszReloadSound2);
+}
+
+EXT_FUNC void CCSPlayerWeapon::KickBack(float up_base, float lateral_base, float up_modifier, float lateral_modifier, float up_max, float lateral_max, int direction_change)
+{
+	BasePlayerWeapon()->KickBack(up_base, lateral_base, up_modifier, lateral_modifier, up_max, lateral_max, direction_change);
+}
+
+EXT_FUNC void CCSPlayerWeapon::SendWeaponAnim(int iAnim, int skiplocal)
+{
+	BasePlayerWeapon()->SendWeaponAnim(iAnim, skiplocal);
 }

--- a/regamedll/dlls/weapons.cpp
+++ b/regamedll/dlls/weapons.cpp
@@ -824,6 +824,10 @@ bool CBasePlayerWeapon::HasSecondaryAttack()
 	{
 		return true;
 	}
+	if (CSPlayerWeapon()->m_bBlockSecondaryAttack)
+	{
+		return false;
+	}
 #endif
 
 	switch (m_iId)
@@ -1196,7 +1200,9 @@ void CBasePlayerWeapon::Spawn()
 		CSPlayerItem()->SetItemInfo(&info);
 	}
 
-	CSPlayerWeapon()->m_bHasSecondaryAttack = HasSecondaryAttack();
+	bool secondaryAble = HasSecondaryAttack();
+	CSPlayerWeapon()->m_bHasSecondaryAttack = secondaryAble;
+	CSPlayerWeapon()->m_bBlockSecondaryAttack = !secondaryAble; // this could be only one member *sigh*
 #endif
 }
 

--- a/regamedll/msvc/ReGameDLL.vcxproj
+++ b/regamedll/msvc/ReGameDLL.vcxproj
@@ -46,6 +46,10 @@
     <ClCompile Include="..\dlls\API\CSPlayerItem.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Tests|Win32'">
       </ExcludedFromBuild>
+    </ClCompile>    
+    <ClCompile Include="..\dlls\API\CSPlayerWeapon.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Tests|Win32'">
+      </ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="..\dlls\basemonster.cpp" />
     <ClCompile Include="..\dlls\bmodels.cpp" />

--- a/regamedll/msvc/ReGameDLL.vcxproj.filters
+++ b/regamedll/msvc/ReGameDLL.vcxproj.filters
@@ -540,6 +540,9 @@
     <ClCompile Include="..\dlls\API\CSPlayerItem.cpp">
       <Filter>dlls\API</Filter>
     </ClCompile>
+    <ClCompile Include="..\dlls\API\CSPlayerWeapon.cpp">
+      <Filter>dlls\API</Filter>
+    </ClCompile>
     <ClCompile Include="..\regamedll\public_amalgamation.cpp">
       <Filter>regamedll</Filter>
     </ClCompile>


### PR DESCRIPTION
- Added CSPlayerWeapon.cpp file to compile list
- Added new member `m_bBlockSecondaryAttack` to natively block SecondaryAttack function on weapons.
- Added 5 callable functions from CSPlayerWeapon method:
     - DefaultDeploy
     - DefaultReload
     - DefaultShotgunReload
     - KickBack
     - SendWeaponAnim