### PR TITLE
`API`: CSPlayer new members (physics related)

### DIFF
--- a/regamedll/pm_shared/pm_shared.cpp
+++ b/regamedll/pm_shared/pm_shared.cpp
@@ -2485,9 +2485,9 @@ void PM_Jump()
 	}
 	
 #ifdef REGAMEDLL_API
-	auto PM_JumpHeight = [&player](bool longjump)
+	real_t PM_JumpHeight = [&player](bool longjump)
 #else 
-	auto PM_JumpHeight = [&](bool longjump)
+	real_t PM_JumpHeight = [&](bool longjump)
 #endif
 	{
 #ifdef REGAMEDLL_API

--- a/regamedll/pm_shared/pm_shared.cpp
+++ b/regamedll/pm_shared/pm_shared.cpp
@@ -2495,7 +2495,7 @@ void PM_Jump()
 	{
 		PM_PlayStepSound(PM_MapTextureTypeStepType(pmove->chtexturetype), fvol);
 	}
-	
+
 #ifdef REGAMEDLL_ADD
 	// See if user can super long jump?
 	bool cansuperjump = (pmove->PM_Info_ValueForKey(pmove->physinfo, "slj")[0] == '1');

--- a/regamedll/pm_shared/pm_shared.cpp
+++ b/regamedll/pm_shared/pm_shared.cpp
@@ -1899,7 +1899,7 @@ void PM_Duck()
 		return;
 	}
 
-	float mult = PLAYER_DUCKING_MULTIPLIER;
+	real_t mult = PLAYER_DUCKING_MULTIPLIER;
 
 #ifdef REGAMEDLL_API
 	const CCSPlayer* player = UTIL_PlayerByIndex(pmove->player_index + 1)->CSPlayer();
@@ -2024,7 +2024,7 @@ void EXT_FUNC __API_HOOK(PM_LadderMove)(physent_t *pLadder)
 
 		if (pmove->flags & FL_DUCKING)
 		{
-			float mult = PLAYER_DUCKING_MULTIPLIER;
+			real_t mult = PLAYER_DUCKING_MULTIPLIER;
 
 #ifdef REGAMEDLL_API
 			const CCSPlayer* player = UTIL_PlayerByIndex(pmove->player_index + 1)->CSPlayer();

--- a/regamedll/pm_shared/pm_shared.cpp
+++ b/regamedll/pm_shared/pm_shared.cpp
@@ -2485,9 +2485,9 @@ void PM_Jump()
 	}
 	
 #ifdef REGAMEDLL_API
-	real_t PM_JumpHeight = [&player](bool longjump)
+	auto PM_JumpHeight = [&player](bool longjump) -> real_t
 #else 
-	real_t PM_JumpHeight = [&](bool longjump)
+	auto PM_JumpHeight = [&](bool longjump) -> real_t
 #endif
 	{
 #ifdef REGAMEDLL_API

--- a/regamedll/public/regamedll/API/CSPlayer.h
+++ b/regamedll/public/regamedll/API/CSPlayer.h
@@ -50,7 +50,11 @@ public:
 		m_bAutoBunnyHopping(false),
 		m_bMegaBunnyJumping(false),
 		m_bPlantC4Anywhere(false),
-		m_bSpawnProtectionEffects(false)
+		m_bSpawnProtectionEffects(false),
+		m_flJumpHeight(0),
+		m_flLongJumpHeight(0),
+		m_flLongJumpForce(0),
+		m_flDuckSpeedMultiplier(0)
 	{
 		m_szModel[0] = '\0';
 	}
@@ -136,6 +140,10 @@ public:
 	bool m_bMegaBunnyJumping;
 	bool m_bPlantC4Anywhere;
 	bool m_bSpawnProtectionEffects;
+	double m_flJumpHeight; 
+	double m_flLongJumpHeight; 
+	double m_flLongJumpForce;
+	float m_flDuckSpeedMultiplier;
 };
 
 // Inlines

--- a/regamedll/public/regamedll/API/CSPlayer.h
+++ b/regamedll/public/regamedll/API/CSPlayer.h
@@ -143,7 +143,7 @@ public:
 	double m_flJumpHeight; 
 	double m_flLongJumpHeight; 
 	double m_flLongJumpForce;
-	float m_flDuckSpeedMultiplier;
+	double m_flDuckSpeedMultiplier;
 };
 
 // Inlines


### PR DESCRIPTION
- Added 4 members to CSPlayer class:
     - `m_flJumpHeight`: player vertical jump force, 0 = default (~268.3)
     - `m_flLongJumpHeight`: player vertical jump force with longjump enabled, 0 = default (~299.3)
     - `m_flLongJumpForce`: player horizontal jump force with longjump enabled, 0 = default (560.0)
     - `m_flDuckSpeedMultiplier`: player duck speed multiplier, 0 = default (0.3333)
- Cached pmove player's CSPlayer pointer in a global variable