### PR TITLE
Ensure m_pDriver assignation on func_vehicle only

### DIFF
--- a/regamedll/dlls/player.cpp
+++ b/regamedll/dlls/player.cpp
@@ -4107,11 +4107,10 @@ void CBasePlayer::PlayerUse()
 			if (pTrain && pTrain->Classify() == CLASS_VEHICLE)
 			{
 #ifdef REGAMEDLL_ADD
-				if (legacy_vehicle_block.value)
-					((CFuncVehicle *)pTrain)->m_pDriver = nullptr;
-#else
-				((CFuncVehicle *)pTrain)->m_pDriver = nullptr;
+				if (legacy_vehicle_block.value == 0)
+					return;
 #endif
+				((CFuncVehicle *)pTrain)->m_pDriver = nullptr;
 			}
 			return;
 		}
@@ -4653,12 +4652,17 @@ void EXT_FUNC CBasePlayer::__API_HOOK(PreThink)()
 			{
 				m_afPhysicsFlags &= ~PFLAG_ONTRAIN;
 				m_iTrain = (TRAIN_NEW | TRAIN_OFF);
-#ifdef REGAMEDLL_ADD
-				if (legacy_vehicle_block.value)
-					((CFuncVehicle *)pTrain)->m_pDriver = nullptr;
-#else
-				((CFuncVehicle *)pTrain)->m_pDriver = nullptr;
+
+#ifdef REGAMEDLL_FIXES 
+				if (pTrain && pTrain->Classify() == CLASS_VEHICLE) // ensure func_vehicle's m_pDriver assignation
 #endif
+				{
+#ifdef REGAMEDLL_ADD
+					if (legacy_vehicle_block.value == 0)
+						return;
+#endif
+					((CFuncVehicle *)pTrain)->m_pDriver = nullptr;
+				}
 				return;
 			}
 		}
@@ -4667,12 +4671,17 @@ void EXT_FUNC CBasePlayer::__API_HOOK(PreThink)()
 			// Turn off the train if you jump, strafe, or the train controls go dead
 			m_afPhysicsFlags &= ~PFLAG_ONTRAIN;
 			m_iTrain = (TRAIN_NEW | TRAIN_OFF);
-#ifdef REGAMEDLL_ADD
-			if (legacy_vehicle_block.value)
-				((CFuncVehicle *)pTrain)->m_pDriver = nullptr;
-#else
-			((CFuncVehicle *)pTrain)->m_pDriver = nullptr;
+
+#ifdef REGAMEDLL_FIXES 
+			if (pTrain->Classify() == CLASS_VEHICLE) // ensure func_vehicle's m_pDriver assignation
 #endif
+			{
+#ifdef REGAMEDLL_ADD
+				if (legacy_vehicle_block.value == 0)
+					return;
+#endif
+				((CFuncVehicle *)pTrain)->m_pDriver = nullptr;
+			}
 			return;
 		}
 


### PR DESCRIPTION
`m_pDriver` is a member present only on `CFuncVehicle` class, in `CBasePlayer` workflow there's a train quitting logic where game is setting `m_pDriver` to `NULL` on both entities **func_vehicle** and **func_tracktrain**, which shares `FCAP_DIRECTIONAL_USE` ObjectCaps flag but the last one doesn't have m_pDriver member (including the implicit cast to CFuncVehicle on code)

Workaround (and ToDo): Train quitting logic is quite similar, should that be grouped in a single function?