### PR TITLE
`FIX`: Reloading animation bug while holding weapon with altered Maxclip

### DIFF
--- a/regamedll/dlls/client.cpp
+++ b/regamedll/dlls/client.cpp
@@ -4824,7 +4824,7 @@ int EXT_FUNC GetWeaponData(edict_t *pEdict, struct weapon_data_s *info)
 					item->iuser1 = weapon->m_iSwing;
 
 #ifdef REGAMEDLL_FIXES
-					if (pPlayerItem == pPlayer->m_pActiveItem && weapon->m_iClip == II.iMaxClip)
+					if (pPlayerItem == pPlayer->m_pActiveItem && !weapon->m_fInReload && weapon->m_iClip == II.iMaxClip)
 					{
 						const WeaponInfoStruct *wpnInfo = GetDefaultWeaponInfo(II.iId);
 

--- a/regamedll/dlls/client.cpp
+++ b/regamedll/dlls/client.cpp
@@ -4817,6 +4817,16 @@ int EXT_FUNC GetWeaponData(edict_t *pEdict, struct weapon_data_s *info)
 					item->fuser2 = weapon->m_flStartThrow;
 					item->fuser3 = weapon->m_flReleaseThrow;
 					item->iuser1 = weapon->m_iSwing;
+
+#ifdef REGAMEDLL_FIXES 
+					if (pPlayerItem == pPlayer->m_pActiveItem && weapon->m_iClip == II.iMaxClip)
+					{
+						int defMaxClip = g_weaponInfo_default[II.iId].gunClipSize;
+
+						if (defMaxClip != II.iMaxClip)
+							item->m_iClip = defMaxClip;
+					}
+#endif
 				}
 			}
 

--- a/regamedll/dlls/client.cpp
+++ b/regamedll/dlls/client.cpp
@@ -4826,10 +4826,10 @@ int EXT_FUNC GetWeaponData(edict_t *pEdict, struct weapon_data_s *info)
 #ifdef REGAMEDLL_FIXES 
 					if (pPlayerItem == pPlayer->m_pActiveItem && weapon->m_iClip == II.iMaxClip)
 					{
-						int defMaxClip = g_weaponInfo_default[II.iId].gunClipSize;
+						const WeaponInfoStruct *wpnInfo = GetDefaultWeaponInfo(II.iId);
 
-						if (defMaxClip != II.iMaxClip)
-							item->m_iClip = defMaxClip;
+						if (wpnInfo->gunClipSize != II.iMaxClip)
+							item->m_iClip = wpnInfo->gunClipSize;
 					}
 #endif
 				}

--- a/regamedll/dlls/client.cpp
+++ b/regamedll/dlls/client.cpp
@@ -4823,13 +4823,13 @@ int EXT_FUNC GetWeaponData(edict_t *pEdict, struct weapon_data_s *info)
 					item->fuser3 = weapon->m_flReleaseThrow;
 					item->iuser1 = weapon->m_iSwing;
 
-#ifdef REGAMEDLL_FIXES 
+#ifdef REGAMEDLL_FIXES
 					if (pPlayerItem == pPlayer->m_pActiveItem && weapon->m_iClip == II.iMaxClip)
 					{
 						const WeaponInfoStruct *wpnInfo = GetDefaultWeaponInfo(II.iId);
 
-						if (wpnInfo->gunClipSize != II.iMaxClip)
-							item->m_iClip = wpnInfo->gunClipSize;
+						if (wpnInfo && wpnInfo->gunClipSize != II.iMaxClip)
+							item->m_iClip = wpnInfo->gunClipSize; 
 					}
 #endif
 				}

--- a/regamedll/dlls/weapontype.cpp
+++ b/regamedll/dlls/weapontype.cpp
@@ -529,7 +529,6 @@ WeaponInfoStruct *GetWeaponInfo(const char *weaponName)
 	return nullptr;
 }
 
-
 WeaponInfoStruct *GetDefaultWeaponInfo(int weaponID)
 {
 	for (auto& info : g_weaponInfo_default) {

--- a/regamedll/dlls/weapontype.cpp
+++ b/regamedll/dlls/weapontype.cpp
@@ -529,6 +529,18 @@ WeaponInfoStruct *GetWeaponInfo(const char *weaponName)
 	return nullptr;
 }
 
+
+WeaponInfoStruct *GetDefaultWeaponInfo(int weaponID)
+{
+	for (auto& info : g_weaponInfo_default) {
+		if (info.id == weaponID) {
+			return &info;
+		}
+	}
+
+	return nullptr;
+}
+
 AmmoInfoStruct *GetAmmoInfo(const char *ammoName)
 {
 	for (auto& info : g_ammoInfo) {

--- a/regamedll/dlls/weapontype.h
+++ b/regamedll/dlls/weapontype.h
@@ -445,6 +445,8 @@ void WeaponInfoReset();
 WeaponInfoStruct *GetWeaponInfo(int weaponID);
 WeaponInfoStruct *GetWeaponInfo(const char *weaponName);
 
+WeaponInfoStruct *GetDefaultWeaponInfo(int weaponID);
+
 AmmoInfoStruct *GetAmmoInfo(AmmoType ammoID);
 AmmoInfoStruct *GetAmmoInfo(const char *ammoName);
 


### PR DESCRIPTION
Sort of an old bug. If client prediction is activated (`cl_lw 1`), player is holding a weapon whose maxclip was altered (easily nowadays with `rg_set_iteminfo` natives), active weapon's clip is equal to altered maxclip, and then presses the reload button, it will reproduce a client-side reload animation which stops until player releases the button, because client thinks you met the conditions to reload the weapon considering its clip differs from its maxclip.

This fixes that weapon animation by faking the weapon's current clip in case the weapon has a different maxclip from its original, and is actually holding the gun with `clip == newmaxclip`.

You can see the conditions in the files changed.

I might say it needs tests 👍