### PR TITLE
`API`: CSPlayer methods enhancement

### DIFF
--- a/regamedll/dlls/API/CSPlayer.cpp
+++ b/regamedll/dlls/API/CSPlayer.cpp
@@ -310,14 +310,14 @@ EXT_FUNC void CCSPlayer::GiveShield(bool bDeploy)
 	BasePlayer()->GiveShield(bDeploy);
 }
 
-EXT_FUNC void CCSPlayer::DropShield(bool bDeploy)
+EXT_FUNC CBaseEntity *CCSPlayer::DropShield(bool bDeploy)
 {
-	BasePlayer()->DropShield(bDeploy);
+	return BasePlayer()->DropShield(bDeploy);
 }
 
-EXT_FUNC void CCSPlayer::DropPlayerItem(const char *pszItemName)
+EXT_FUNC CBaseEntity *CCSPlayer::DropPlayerItem(const char *pszItemName)
 {
-	BasePlayer()->DropPlayerItem(pszItemName);
+	return BasePlayer()->DropPlayerItem(pszItemName);
 }
 
 EXT_FUNC bool CCSPlayer::RemoveShield()

--- a/regamedll/dlls/API/CSPlayer.cpp
+++ b/regamedll/dlls/API/CSPlayer.cpp
@@ -43,8 +43,10 @@ EXT_FUNC bool CCSPlayer::JoinTeam(TeamName team)
 		pPlayer->pev->deadflag = DEAD_DEAD;
 		pPlayer->pev->health = 0;
 
+		if (pPlayer->m_bHasC4)
+			pPlayer->DropPlayerItem("weapon_c4");
+
 		pPlayer->RemoveAllItems(TRUE);
-		pPlayer->m_bHasC4 = false;
 
 		pPlayer->m_iTeam = SPECTATOR;
 		pPlayer->m_iJoiningState = JOINED;

--- a/regamedll/public/regamedll/API/CSPlayer.h
+++ b/regamedll/public/regamedll/API/CSPlayer.h
@@ -66,8 +66,8 @@ public:
 	virtual CBaseEntity *GiveNamedItemEx(const char *pszName);
 	virtual void GiveDefaultItems();
 	virtual void GiveShield(bool bDeploy = true);
-	virtual void DropShield(bool bDeploy = true);
-	virtual void DropPlayerItem(const char *pszItemName);
+	virtual CBaseEntity *DropShield(bool bDeploy = true);
+	virtual CBaseEntity* DropPlayerItem(const char *pszItemName);
 	virtual bool RemoveShield();
 	virtual void RemoveAllItems(bool bRemoveSuit);
 	virtual bool RemovePlayerItem(const char* pszItemName);


### PR DESCRIPTION
- Added C4 drop when changing from CT/T to SPEC
     - Deleted `m_bHasC4` assignation to false due to code redundancy in `RemoveAllItems`
- Changed return types of `DropShield` and `DropPlayerItem` to `CBaseEntity` to retrieve created entity index.

This requieres to update API version and submodules like ReAPI. (actually done)

EDIT: this partially grabs #699 changes in a segmented/detailed way