### PR TITLE
Refactored RemovePlayerItemEx and Extended DestroyItem in CBasePlayerItem

### DIFF
--- a/regamedll/dlls/API/CSPlayer.cpp
+++ b/regamedll/dlls/API/CSPlayer.cpp
@@ -217,38 +217,20 @@ EXT_FUNC bool CCSPlayer::RemovePlayerItemEx(const char* pszItemName, bool bRemov
 					return true; // ammo was reduced, this will be considered a successful result
 			}
 
+			if (bRemoveAmmo) {
+				pPlayer->m_rgAmmo[pItem->PrimaryAmmoIndex()] = 0;
+			}
+
 			if (pItem == pPlayer->m_pActiveItem) {
 				((CBasePlayerWeapon *)pItem)->RetireWeapon();
-			}
-
-			if (bRemoveAmmo) {
-				pPlayer->m_rgAmmo[ pItem->PrimaryAmmoIndex() ] = 0;
+				
+				if (pItem->CanHolster() && pItem != pPlayer->m_pActiveItem && !(pPlayer->pev->weapons &(1 << pItem->m_iId))) {
+					return true;
+				}
 			}
 		}
 
-		if (pPlayer->RemovePlayerItem(pItem))
-		{
-			if (FClassnameIs(pItem->pev, "weapon_c4")) {
-				pPlayer->m_bHasC4 = false;
-				pPlayer->pev->body = 0;
-				pPlayer->SetBombIcon(FALSE);
-				pPlayer->SetProgressBarTime(0);
-			}
-
-			pPlayer->pev->weapons &= ~(1 << pItem->m_iId);
-			// No more weapon
-			if ((pPlayer->pev->weapons & ~(1 << WEAPON_SUIT)) == 0) {
-				pPlayer->m_iHideHUD |= HIDEHUD_WEAPONS;
-			}
-
-			pItem->Kill();
-
-			if (!pPlayer->m_rgpPlayerItems[PRIMARY_WEAPON_SLOT]) {
-				pPlayer->m_bHasPrimary = false;
-			}
-
-			return true;
-		}
+		return pItem->DestroyItem();
 	}
 
 	return false;

--- a/regamedll/dlls/player.cpp
+++ b/regamedll/dlls/player.cpp
@@ -8494,7 +8494,6 @@ void CStripWeapons::Use(CBaseEntity *pActivator, CBaseEntity *pCaller, USE_TYPE 
 
 				if (slot == ALL_OTHER_ITEMS)
 				{
-					pPlayer->CSPlayer()->RemovePlayerItem("item_thighpack");
 					pPlayer->CSPlayer()->RemovePlayerItem("item_longjump");
 					pPlayer->CSPlayer()->RemovePlayerItem("item_assaultsuit");
 					pPlayer->CSPlayer()->RemovePlayerItem("item_kevlar");

--- a/regamedll/dlls/weapons.cpp
+++ b/regamedll/dlls/weapons.cpp
@@ -1128,8 +1128,10 @@ void EXT_FUNC CBasePlayerWeapon::__API_HOOK(ItemPostFrame)()
 	}
 }
 
-void CBasePlayerItem::DestroyItem()
+bool CBasePlayerItem::DestroyItem()
 {
+	bool success = false;
+
 	if (m_pPlayer)
 	{
 		// if attached to a player, remove.
@@ -1137,18 +1139,31 @@ void CBasePlayerItem::DestroyItem()
 		{
 
 #ifdef REGAMEDLL_FIXES
+			if (m_iId == WEAPON_C4) {
+				m_pPlayer->m_bHasC4 = false;
+				m_pPlayer->pev->body = 0;
+				m_pPlayer->SetBombIcon(FALSE);
+				m_pPlayer->SetProgressBarTime(0);
+			}
+
 			m_pPlayer->pev->weapons &= ~(1 << m_iId);
 
 			// No more weapon
 			if ((m_pPlayer->pev->weapons & ~(1 << WEAPON_SUIT)) == 0) {
 				m_pPlayer->m_iHideHUD |= HIDEHUD_WEAPONS;
 			}
-#endif
 
+			if (!m_pPlayer->m_rgpPlayerItems[PRIMARY_WEAPON_SLOT]) {
+				m_pPlayer->m_bHasPrimary = false;
+			}
+#endif
+			success = true;
 		}
 	}
 
 	Kill();
+
+	return success;
 }
 
 int CBasePlayerItem::AddToPlayer(CBasePlayer *pPlayer)

--- a/regamedll/dlls/weapons.h
+++ b/regamedll/dlls/weapons.h
@@ -296,7 +296,7 @@ public:
 	virtual int iItemSlot() { return 0; }									// return 0 to MAX_ITEMS_SLOTS, used in hud
 
 public:
-	void EXPORT DestroyItem();
+	bool EXPORT DestroyItem();
 	void EXPORT DefaultTouch(CBaseEntity *pOther);
 	void EXPORT FallThink();
 	void EXPORT Materialize();


### PR DESCRIPTION
Extension of the DestroyItem method for the CBasePlayerItem class
- Added a boolean value to indicate the success of item deletion
- Implemented a condition for handling WEAPON_C4 specifically
- Added a condition to check for the presence of primary weapons

Updated the item removal mechanism in the RemovePlayerItemEx method
- Fixed a double hook invocation issue for grenades and performed minor code refactoring

Fix duplicate remove of item_thighpack