### PR TITLE
DropPlayerItem: Ensure HasPrimary flag assignation on successful weapon removal

### DIFF
--- a/regamedll/dlls/player.cpp
+++ b/regamedll/dlls/player.cpp
@@ -8051,8 +8051,10 @@ CBaseEntity *EXT_FUNC CBasePlayer::__API_HOOK(DropPlayerItem)(const char *pszIte
 		g_pGameRules->GetNextBestWeapon(this, pWeapon);
 		UTIL_MakeVectors(pev->angles);
 
+#ifndef REGAMEDLL_FIXES
 		if (pWeapon->iItemSlot() == PRIMARY_WEAPON_SLOT)
-			m_bHasPrimary = false;
+			m_bHasPrimary = false; // I may have more than just 1 primary weapon :)
+#endif
 
 		if (FClassnameIs(pWeapon->pev, "weapon_c4"))
 		{
@@ -8121,6 +8123,12 @@ CBaseEntity *EXT_FUNC CBasePlayer::__API_HOOK(DropPlayerItem)(const char *pszIte
 		{
 			return nullptr;
 		}
+
+#ifdef REGAMEDLL_FIXES
+		if (!m_rgpPlayerItems[PRIMARY_WEAPON_SLOT]) {
+			m_bHasPrimary = false; // ensure value assignation on successful weapon removal
+		}
+#endif
 
 		if (FClassnameIs(pWeapon->pev, "weapon_c4"))
 		{


### PR DESCRIPTION
- Ensuring m_bHasPrimary member assignation when dropping a primary weapon, you can have more than 1 weapon (in modded scenarios) and you can grab a shield by just dropping one weapon.
- Ensuring m_bHasPrimary member assignation every time a weaponbox entity is successfully created (in modified scenarios)