### PR TITLE
Unreleased content: Drop defuser on disconnect

### DIFF
--- a/regamedll/dlls/multiplay_gamerules.cpp
+++ b/regamedll/dlls/multiplay_gamerules.cpp
@@ -3586,14 +3586,15 @@ void CHalfLifeMultiplay::ClientDisconnected(edict_t *pClient)
 			{
 				pPlayer->DropPlayerItem("weapon_c4");
 			}
-
-#ifndef REGAMEDLL_FIXES
-			// Why ? DropPlayerItem didn't handle item_thighpack
+	
 			if (pPlayer->m_bHasDefuser)
 			{
-				pPlayer->DropPlayerItem("item_thighpack");
-			}
+#ifdef REGAMEDLL_FIXES
+				SpawnDefuser(pPlayer->pev->origin, nullptr);
+#else
+				pPlayer->DropPlayerItem("item_thighpack"); // DropPlayerItem didn't handle item_thighpack
 #endif
+			}
 
 			if (pPlayer->m_bIsVIP)
 			{


### PR DESCRIPTION
In original CS behaviour it was expected to drop a defuser when a player disconnects if carrying. This enables that feature by creating an `item_thighpack` entity on the position of the disconnected player.

ToDo: discuss the fact of adding a cvar to enable/disable this new change that can alter game behaviour in "competitive" scenarios.