### PR TITLE
Observer_SetMode: Use Observer_IsValidPlayer function inside

### DIFF
--- a/regamedll/dlls/observer.cpp
+++ b/regamedll/dlls/observer.cpp
@@ -478,10 +478,19 @@ void EXT_FUNC CBasePlayer::__API_HOOK(Observer_SetMode)(int iMode)
 	// verify observer target again
 	if (m_hObserverTarget)
 	{
+#ifdef REGAMEDLL_FIXES
+		m_hObserverTarget = Observer_IsValidTarget( ENTINDEX(m_hObserverTarget->edict()), forcecamera != CAMERA_MODE_SPEC_ANYONE );
+#else 
 		CBasePlayer *pTarget = m_hObserverTarget;
 
-		if (pTarget == this || !pTarget || pTarget->has_disconnected || pTarget->GetObserverMode() != OBS_NONE || (pTarget->pev->effects & EF_NODRAW) || (forcecamera != CAMERA_MODE_SPEC_ANYONE && pTarget->m_iTeam != m_iTeam))
+		if (pTarget == this 
+			|| !pTarget 
+			|| pTarget->has_disconnected 
+			|| pTarget->GetObserverMode() != OBS_NONE 
+			|| (pTarget->pev->effects & EF_NODRAW) 
+			|| (forcecamera != CAMERA_MODE_SPEC_ANYONE && pTarget->m_iTeam != m_iTeam))
 			m_hObserverTarget = nullptr;
+#endif
 	}
 
 	// set spectator mode


### PR DESCRIPTION
This isn't coded in the original binary. `Observer_IsValidPlayer `meets conditions in a statement inside `Observer_SetMode `with a few differences. This PR just calls this function instead which wont behave different and allows modders a better handling of target choosing.