### PR TITLE
Avoid intro camera switching when only 1 trigger_camera available

### DIFF
--- a/regamedll/dlls/client.cpp
+++ b/regamedll/dlls/client.cpp
@@ -675,7 +675,12 @@ void EXT_FUNC ClientPutInServer(edict_t *pEntity)
 
 	if (g_pGameRules && g_pGameRules->IsMultiplayer())
 	{
+#ifdef REGAMEDLL_FIXES 
+		if (CSGameRules()->m_bMapHasCameras < 0)
+			CSGameRules()->m_bMapHasCameras = UTIL_CountEntities("trigger_camera");
+#else
 		CSGameRules()->m_bMapHasCameras = (pPlayer->m_pIntroCamera != nullptr);
+#endif
 	}
 
 	if (pPlayer->m_pIntroCamera)
@@ -694,7 +699,12 @@ void EXT_FUNC ClientPutInServer(edict_t *pEntity)
 		pPlayer->pev->angles = CamAngles;
 		pPlayer->pev->v_angle = pPlayer->pev->angles;
 
-		pPlayer->m_fIntroCamTime = gpGlobals->time + 6;
+		pPlayer->m_fIntroCamTime = 
+#ifdef REGAMEDLL_FIXES 
+			(CSGameRules()->m_bMapHasCameras <= 1) ? 0.0 : // no need to refresh cameras if map has only one
+#else 
+			gpGlobals->time + 6;
+
 		pPlayer->pev->view_ofs = g_vecZero;
 	}
 #ifndef REGAMEDLL_FIXES

--- a/regamedll/dlls/client.cpp
+++ b/regamedll/dlls/client.cpp
@@ -676,7 +676,7 @@ void EXT_FUNC ClientPutInServer(edict_t *pEntity)
 	if (g_pGameRules && g_pGameRules->IsMultiplayer())
 	{
 #ifdef REGAMEDLL_FIXES 
-		if (CSGameRules()->m_bMapHasCameras < 0)
+		if (CSGameRules()->m_bMapHasCameras < 0) // cache once
 			CSGameRules()->m_bMapHasCameras = UTIL_CountEntities("trigger_camera");
 #else
 		CSGameRules()->m_bMapHasCameras = (pPlayer->m_pIntroCamera != nullptr);
@@ -702,7 +702,7 @@ void EXT_FUNC ClientPutInServer(edict_t *pEntity)
 		pPlayer->m_fIntroCamTime = 
 #ifdef REGAMEDLL_FIXES 
 			(CSGameRules()->m_bMapHasCameras <= 1) ? 0.0 : // no need to refresh cameras if map has only one
-#else 
+#endif
 			gpGlobals->time + 6;
 
 		pPlayer->pev->view_ofs = g_vecZero;

--- a/regamedll/dlls/client.cpp
+++ b/regamedll/dlls/client.cpp
@@ -673,15 +673,12 @@ void EXT_FUNC ClientPutInServer(edict_t *pEntity)
 	CBaseEntity *pTarget = nullptr;
 	pPlayer->m_pIntroCamera = UTIL_FindEntityByClassname(nullptr, "trigger_camera");
 
+#ifndef REGAMEDLL_FIXES 
 	if (g_pGameRules && g_pGameRules->IsMultiplayer())
 	{
-#ifdef REGAMEDLL_FIXES 
-		if (CSGameRules()->m_bMapHasCameras < 0) // cache once
-			CSGameRules()->m_bMapHasCameras = UTIL_CountEntities("trigger_camera");
-#else
 		CSGameRules()->m_bMapHasCameras = (pPlayer->m_pIntroCamera != nullptr);
-#endif
 	}
+#endif
 
 	if (pPlayer->m_pIntroCamera)
 	{

--- a/regamedll/dlls/gamerules.h
+++ b/regamedll/dlls/gamerules.h
@@ -779,7 +779,7 @@ public:
 	bool m_bMapHasEscapeZone;
 
 	BOOL m_bMapHasVIPSafetyZone;			// TRUE = has VIP safety zone, FALSE = does not have VIP safetyzone
-	BOOL m_bMapHasCameras;
+	int m_bMapHasCameras;
 	int m_iC4Timer;
 	int m_iC4Guy;							// The current Terrorist who has the C4.
 	int m_iLoserBonus;						// the amount of money the losing team gets. This scales up as they lose more rounds in a row

--- a/regamedll/dlls/multiplay_gamerules.cpp
+++ b/regamedll/dlls/multiplay_gamerules.cpp
@@ -382,7 +382,7 @@ CHalfLifeMultiplay::CHalfLifeMultiplay()
 	m_iNumTerrorist = 0;
 	m_iNumSpawnableCT = 0;
 	m_iNumSpawnableTerrorist = 0;
-	m_bMapHasCameras = FALSE;
+	m_bMapHasCameras = -1;
 
 	m_iLoserBonus = m_rgRewardAccountRules[RR_LOSER_BONUS_DEFAULT];
 	m_iNumConsecutiveCTLoses = 0;
@@ -3084,17 +3084,8 @@ void CHalfLifeMultiplay::CheckLevelInitialized()
 	{
 		// Count the number of spawn points for each team
 		// This determines the maximum number of players allowed on each
-		CBaseEntity *pEnt = nullptr;
-
-		m_iSpawnPointCount_Terrorist = 0;
-		m_iSpawnPointCount_CT = 0;
-
-		while ((pEnt = UTIL_FindEntityByClassname(pEnt, "info_player_deathmatch")))
-			m_iSpawnPointCount_Terrorist++;
-
-		while ((pEnt = UTIL_FindEntityByClassname(pEnt, "info_player_start")))
-			m_iSpawnPointCount_CT++;
-
+		m_iSpawnPointCount_Terrorist = UTIL_CountEntities("info_player_deathmatch");
+		m_iSpawnPointCount_CT = UTIL_CountEntities("info_player_start");
 		m_bLevelInitialized = true;
 	}
 }

--- a/regamedll/dlls/multiplay_gamerules.cpp
+++ b/regamedll/dlls/multiplay_gamerules.cpp
@@ -3088,6 +3088,9 @@ void CHalfLifeMultiplay::CheckLevelInitialized()
 		// This determines the maximum number of players allowed on each
 		m_iSpawnPointCount_Terrorist = UTIL_CountEntities("info_player_deathmatch");
 		m_iSpawnPointCount_CT = UTIL_CountEntities("info_player_start");
+#ifdef REGAMEDLL_FIXES 
+		m_bMapHasCameras = UTIL_CountEntities("trigger_camera");
+#endif
 		m_bLevelInitialized = true;
 	}
 }

--- a/regamedll/dlls/player.cpp
+++ b/regamedll/dlls/player.cpp
@@ -3673,7 +3673,11 @@ void EXT_FUNC CBasePlayer::__API_HOOK(JoiningThink)()
 		}
 	}
 
-	if (m_pIntroCamera && gpGlobals->time >= m_fIntroCamTime)
+	if (m_pIntroCamera && gpGlobals->time >= m_fIntroCamTime
+#ifdef REGAMEDLL_FIXES 
+		&& m_fIntroCamTime > 0.0 // update only if cameras are available
+#endif
+		)
 	{
 		// find the next another camera
 		m_pIntroCamera = UTIL_FindEntityByClassname(m_pIntroCamera, "trigger_camera");

--- a/regamedll/dlls/util.cpp
+++ b/regamedll/dlls/util.cpp
@@ -1758,6 +1758,17 @@ int UTIL_GetNumPlayers()
 	return nNumPlayers;
 }
 
+int UTIL_CountEntities(const char *szName)
+{
+	int count = 0;
+	CBaseEntity *pEnt = nullptr;
+
+	while ((pEnt = UTIL_FindEntityByClassname(pEnt, szName)))
+		count++;
+
+	return count;
+}
+
 bool UTIL_IsSpawnPointOccupied(CBaseEntity *pSpot)
 {
 	if (!pSpot)

--- a/regamedll/dlls/util.h
+++ b/regamedll/dlls/util.h
@@ -297,6 +297,7 @@ bool UTIL_AreBotsAllowed();
 bool UTIL_IsBeta();
 bool UTIL_AreHostagesImprov();
 int UTIL_GetNumPlayers();
+int UTIL_CountEntities(const char *szName);
 bool UTIL_IsSpawnPointOccupied(CBaseEntity *pSpot);
 void MAKE_STRING_CLASS(const char *str, entvars_t *pev);
 void NORETURN Sys_Error(const char *error, ...);


### PR DESCRIPTION
This PR omits the logic that changes the player's introduction camera to it (the same), which forces a rather annoying change of angles because there is no behavior that verifies if there is more than just one trigger_camera.

- `m_bMapHasCameras` member from `CSGameRules` changed type to `int`, which is the same as `BOOL` internally, and it counts the number of `trigger_camera` entities in the map.
  - It is cached once on `ClientPutInServer`.
  - Default value in the construction of the `CSGameRules` class is now -1 (ToDo: I don't think I need to enclose that with the fixes macro).
- `m_fIntroCamTime` is assigned to 0.0 if there's just only one `trigger_camera`, so it wont force an unnecesary camera updating every 6 seconds. A simple condition was added in the related thinking function `JoiningThink`.
- Extra: code cleaning inside `CheckLevelInitialized` on the counting of `info_player_*` entities using the added function `UTIL_CountEntities`.