### PR TITLE
Fixed grenades disappearing when speed exceeds 2000 fixed units ignoring sv_maxvelocity

### DIFF
--- a/regamedll/dlls/cbase.cpp
+++ b/regamedll/dlls/cbase.cpp
@@ -865,12 +865,18 @@ BOOL CBaseEntity::IsInWorld()
 		return FALSE;
 	}
 
+#ifdef REGAMEDLL_FIXES
+	double maxvel = g_psv_maxvelocity->value;
+#else
+	double maxvel = 2000.0;
+#endif
+
 	// speed
-	if (pev->velocity.x >= 2000.0 || pev->velocity.y >= 2000.0 || pev->velocity.z >= 2000.0)
+	if (pev->velocity.x >= maxvel || pev->velocity.y >= maxvel || pev->velocity.z >= maxvel)
 	{
 		return FALSE;
 	}
-	if (pev->velocity.x <= -2000.0 || pev->velocity.y <= -2000.0 || pev->velocity.z <= -2000.0)
+	if (pev->velocity.x <= -maxvel || pev->velocity.y <= -maxvel || pev->velocity.z <= -maxvel)
 	{
 		return FALSE;
 	}

--- a/regamedll/dlls/cbase.cpp
+++ b/regamedll/dlls/cbase.cpp
@@ -867,7 +867,7 @@ BOOL CBaseEntity::IsInWorld()
 
 	// speed
 #ifdef REGAMEDLL_FIXES
-	double maxvel = g_psv_maxvelocity->value;
+	float maxvel = g_psv_maxvelocity->value;
 	if (pev->velocity.x > maxvel || pev->velocity.y > maxvel || pev->velocity.z > maxvel)
 	{
 		return FALSE;

--- a/regamedll/dlls/cbase.cpp
+++ b/regamedll/dlls/cbase.cpp
@@ -872,11 +872,11 @@ BOOL CBaseEntity::IsInWorld()
 #endif
 
 	// speed
-	if (pev->velocity.x >= maxvel || pev->velocity.y >= maxvel || pev->velocity.z >= maxvel)
+	if (pev->velocity.x > maxvel || pev->velocity.y > maxvel || pev->velocity.z > maxvel)
 	{
 		return FALSE;
 	}
-	if (pev->velocity.x <= -maxvel || pev->velocity.y <= -maxvel || pev->velocity.z <= -maxvel)
+	if (pev->velocity.x < -maxvel || pev->velocity.y < -maxvel || pev->velocity.z < -maxvel)
 	{
 		return FALSE;
 	}

--- a/regamedll/dlls/cbase.cpp
+++ b/regamedll/dlls/cbase.cpp
@@ -865,13 +865,9 @@ BOOL CBaseEntity::IsInWorld()
 		return FALSE;
 	}
 
+	// speed
 #ifdef REGAMEDLL_FIXES
 	double maxvel = g_psv_maxvelocity->value;
-#else
-	double maxvel = 2000.0;
-#endif
-
-	// speed
 	if (pev->velocity.x > maxvel || pev->velocity.y > maxvel || pev->velocity.z > maxvel)
 	{
 		return FALSE;
@@ -880,6 +876,16 @@ BOOL CBaseEntity::IsInWorld()
 	{
 		return FALSE;
 	}
+#else
+	if (pev->velocity.x >= 2000.0 || pev->velocity.y >= 2000.0 || pev->velocity.z >= 2000.0)
+	{
+		return FALSE;
+	}
+	if (pev->velocity.x <= -2000.0 || pev->velocity.y <= -2000.0 || pev->velocity.z <= -2000.0)
+	{
+		return FALSE;
+	}
+#endif
 
 	return TRUE;
 }

--- a/regamedll/dlls/game.cpp
+++ b/regamedll/dlls/game.cpp
@@ -9,6 +9,7 @@ cvar_t *g_psv_friction    = nullptr;
 cvar_t *g_psv_stopspeed   = nullptr;
 cvar_t *g_psv_stepsize    = nullptr;
 cvar_t *g_psv_clienttrace = nullptr;
+cvar_t *g_psv_maxvelocity = nullptr;
 
 cvar_t displaysoundlist      = { "displaysoundlist", "0", 0, 0.0f, nullptr };
 cvar_t timelimit             = { "mp_timelimit", "0", FCVAR_SERVER, 0.0f, nullptr };
@@ -236,6 +237,7 @@ void EXT_FUNC GameDLLInit()
 	g_psv_stopspeed   = CVAR_GET_POINTER("sv_stopspeed");
 	g_psv_stepsize    = CVAR_GET_POINTER("sv_stepsize");
 	g_psv_clienttrace = CVAR_GET_POINTER("sv_clienttrace");
+	g_psv_maxvelocity = CVAR_GET_POINTER("sv_maxvelocity");
 
 	CVAR_REGISTER(&displaysoundlist);
 	CVAR_REGISTER(&timelimit);

--- a/regamedll/dlls/game.h
+++ b/regamedll/dlls/game.h
@@ -43,12 +43,13 @@
 extern cvar_t *g_pskill;
 extern cvar_t *g_psv_gravity;
 extern cvar_t *g_psv_aim;
+extern cvar_t *g_footsteps;
 extern cvar_t *g_psv_accelerate;
 extern cvar_t *g_psv_friction;
 extern cvar_t *g_psv_stopspeed;
 extern cvar_t *g_psv_stepsize;
 extern cvar_t *g_psv_clienttrace;
-extern cvar_t *g_footsteps;
+extern cvar_t *g_psv_maxvelocity;
 
 extern cvar_t displaysoundlist;
 extern cvar_t timelimit;

--- a/regamedll/dlls/ggrenade.cpp
+++ b/regamedll/dlls/ggrenade.cpp
@@ -772,6 +772,13 @@ void CGrenade::BounceSound()
 
 void CGrenade::TumbleThink()
 {
+#ifdef REGAMEDLL_FIXES
+	if (pev->velocity.IsLengthGreaterThan(g_psv_maxvelocity->value))
+	{
+		pev->velocity = pev->velocity.Normalize() * g_psv_maxvelocity->value;
+	}
+#endif
+
 	if (!IsInWorld())
 	{
 		UTIL_Remove(this);
@@ -809,6 +816,13 @@ void CGrenade::TumbleThink()
 
 void CGrenade::SG_TumbleThink()
 {
+#ifdef REGAMEDLL_FIXES
+	if (pev->velocity.IsLengthGreaterThan(g_psv_maxvelocity->value))
+	{
+		pev->velocity = pev->velocity.Normalize() * g_psv_maxvelocity->value;
+	}
+#endif
+
 	if (!IsInWorld())
 	{
 		UTIL_Remove(this);
@@ -1322,6 +1336,13 @@ void AnnounceFlashInterval(float interval, float offset)
 
 void CGrenade::C4Think()
 {
+#ifdef REGAMEDLL_FIXES
+	if (pev->velocity.IsLengthGreaterThan(g_psv_maxvelocity->value))
+	{
+		pev->velocity = pev->velocity.Normalize() * g_psv_maxvelocity->value;
+	}
+#endif
+
 	if (!IsInWorld())
 	{
 #ifdef REGAMEDLL_FIXES

--- a/regamedll/dlls/gib.cpp
+++ b/regamedll/dlls/gib.cpp
@@ -5,7 +5,7 @@ LINK_ENTITY_TO_CLASS(gib, CGib, CCSGib)
 void CGib::LimitVelocity()
 {
 	float length = pev->velocity.Length();
-	float topspeed = CVAR_GET_FLOAT("sv_maxvelocity") * 0.75f;
+	float topspeed = g_psv_maxvelocity->value * 0.75f;
 
 	// ceiling at topspeed.  The gib velocity equation is not bounded properly.  Rather than tune it
 	// in 3 separate places again, I'll just limit it here.

--- a/regamedll/dlls/gib.cpp
+++ b/regamedll/dlls/gib.cpp
@@ -4,12 +4,11 @@ LINK_ENTITY_TO_CLASS(gib, CGib, CCSGib)
 
 void CGib::LimitVelocity()
 {
-	float length = pev->velocity.Length();
 	float topspeed = g_psv_maxvelocity->value * 0.75f;
 
 	// ceiling at topspeed.  The gib velocity equation is not bounded properly.  Rather than tune it
 	// in 3 separate places again, I'll just limit it here.
-	if (length > topspeed)
+	if (pev->velocity.IsLengthGreaterThan(topspeed))
 	{
 		// DONE: This should really be sv_maxvelocity * 0.75 or something
 		pev->velocity = pev->velocity.Normalize() * topspeed;


### PR DESCRIPTION
Issue #887 

Added cvar pointer caching of sv_maxvelocity. Did a little research on engine and haven't found more hardcoded usages of 2000 units.