### PR TITLE
Use CSEntity member to hold last inflictor from TakeDamage

### DIFF
--- a/regamedll/dlls/basemonster.cpp
+++ b/regamedll/dlls/basemonster.cpp
@@ -451,17 +451,13 @@ BOOL CBaseMonster::TakeDamage(entvars_t *pevInflictor, entvars_t *pevAttacker, f
 
 	if (pev->health <= 0.0f)
 	{
-		g_pevLastInflictor = pevInflictor;
-
 		if (bitsDamageType & DMG_ALWAYSGIB)
-			Killed(pevAttacker, GIB_ALWAYS);
-
+			KilledInflicted(pevInflictor, pevAttacker, GIB_ALWAYS);
 		else if (bitsDamageType & DMG_NEVERGIB)
-			Killed(pevAttacker, GIB_NEVER);
+			KilledInflicted(pevInflictor, pevAttacker, GIB_NEVER);
 		else
-			Killed(pevAttacker, GIB_NORMAL);
+			KilledInflicted(pevInflictor, pevAttacker, GIB_NORMAL);
 
-		g_pevLastInflictor = nullptr;
 		return FALSE;
 	}
 	if ((pev->flags & FL_MONSTER) && !FNullEnt(pevAttacker))

--- a/regamedll/dlls/cbase.cpp
+++ b/regamedll/dlls/cbase.cpp
@@ -697,7 +697,11 @@ BOOL CBaseEntity::TakeDamage(entvars_t *pevInflictor, entvars_t *pevAttacker, fl
 	pev->health -= flDamage;
 	if (pev->health <= 0)
 	{
+#ifdef REGAMEDLL_FIXES
+		KilledInflicted(pevInflictor, pevAttacker, GIB_NORMAL);
+#else
 		Killed(pevAttacker, GIB_NORMAL);
+#endif
 		return FALSE;
 	}
 

--- a/regamedll/dlls/cbase.h
+++ b/regamedll/dlls/cbase.h
@@ -246,6 +246,9 @@ public:
 	void ResetDmgPenetrationLevel();
 	int GetDmgPenetrationLevel() const;
 
+	void KilledInflicted(entvars_t *pevInflictor, entvars_t *pevAttacker, int iGib);
+	entvars_t *GetLastInflictor();
+
 #ifdef REGAMEDLL_API
 	CCSEntity *m_pEntity;
 	CCSEntity *CSEntity() const;

--- a/regamedll/dlls/player.cpp
+++ b/regamedll/dlls/player.cpp
@@ -82,7 +82,9 @@ const char *CDeadHEV::m_szPoses[] =
 	"deadtable"
 };
 
+#ifndef REGAMEDLL_API
 entvars_t *g_pevLastInflictor;
+#endif
 
 LINK_ENTITY_TO_CLASS(player, CBasePlayer, CCSPlayer)
 
@@ -2130,7 +2132,7 @@ void EXT_FUNC CBasePlayer::__API_HOOK(Killed)(entvars_t *pevAttacker, int iGib)
 					if (IsBot() && IsBlind()) // dystopm: shouldn't be !IsBot() ?
 						wasBlind = true;
 
-					TheCareerTasks->HandleEnemyKill(wasBlind, GetKillerWeaponName(g_pevLastInflictor, pevAttacker), m_bHeadshotKilled, killerHasShield, pAttacker, this); // last 2 param swapped to match function definition
+					TheCareerTasks->HandleEnemyKill(wasBlind, GetKillerWeaponName(GetLastInflictor(), pevAttacker), m_bHeadshotKilled, killerHasShield, pAttacker, this); // last 2 param swapped to match function definition
 				}
 			}
 #endif
@@ -2161,7 +2163,7 @@ void EXT_FUNC CBasePlayer::__API_HOOK(Killed)(entvars_t *pevAttacker, int iGib)
 				{
 					if (TheCareerTasks)
 					{
-						TheCareerTasks->HandleEnemyKill(wasBlind, GetKillerWeaponName(g_pevLastInflictor, pevAttacker), m_bHeadshotKilled, killerHasShield, this, pPlayer);
+						TheCareerTasks->HandleEnemyKill(wasBlind, GetKillerWeaponName(GetLastInflictor(), pevAttacker), m_bHeadshotKilled, killerHasShield, this, pPlayer);
 					}
 				}
 			}
@@ -2171,7 +2173,7 @@ void EXT_FUNC CBasePlayer::__API_HOOK(Killed)(entvars_t *pevAttacker, int iGib)
 
 	if (!m_bKilledByBomb)
 	{
-		g_pGameRules->PlayerKilled(this, pevAttacker, g_pevLastInflictor);
+		g_pGameRules->PlayerKilled(this, pevAttacker, GetLastInflictor());
 	}
 
 	MESSAGE_BEGIN(MSG_ONE, gmsgNVGToggle, nullptr, pev);

--- a/regamedll/dlls/player.h
+++ b/regamedll/dlls/player.h
@@ -975,7 +975,9 @@ inline CBasePlayer *UTIL_PlayerByIndexSafe(int playerIndex)
 	return pPlayer;
 }
 
+#ifndef REGAMEDLL_API
 extern entvars_t *g_pevLastInflictor;
+#endif
 extern CBaseEntity *g_pLastSpawn;
 extern CBaseEntity *g_pLastCTSpawn;
 extern CBaseEntity *g_pLastTerroristSpawn;

--- a/regamedll/public/regamedll/API/CSEntity.h
+++ b/regamedll/public/regamedll/API/CSEntity.h
@@ -46,12 +46,13 @@ public:
 public:
 	CBaseEntity *m_pContainingEntity;
 	unsigned char m_ucDmgPenetrationLevel; // penetration level of the damage caused by the inflictor
+	entvars_t *m_pevLastInflictor;
 
 private:
 #if defined(_MSC_VER)
 #pragma region reserve_data_Region
 #endif
-	char CCSEntity_Reserve[0x3FFF];
+	char CCSEntity_Reserve[0x3FF7];
 
 	virtual void func_reserve1() {};
 	virtual void func_reserve2() {};
@@ -91,23 +92,49 @@ private:
 inline void CBaseEntity::SetDmgPenetrationLevel(int iPenetrationLevel)
 {
 #ifdef REGAMEDLL_API
-	m_pEntity->m_ucDmgPenetrationLevel = iPenetrationLevel;
+	CSEntity()->m_ucDmgPenetrationLevel = iPenetrationLevel;
 #endif
 }
 
 inline void CBaseEntity::ResetDmgPenetrationLevel()
 {
 #ifdef REGAMEDLL_API
-	m_pEntity->m_ucDmgPenetrationLevel = 0;
+	CSEntity()->m_ucDmgPenetrationLevel = 0;
 #endif
 }
 
 inline int CBaseEntity::GetDmgPenetrationLevel() const
 {
 #ifdef REGAMEDLL_API
-	return m_pEntity->m_ucDmgPenetrationLevel;
+	return CSEntity()->m_ucDmgPenetrationLevel;
 #else
 	return 0;
+#endif
+}
+
+inline void CBaseEntity::KilledInflicted(entvars_t* pevInflictor, entvars_t *pevAttacker, int iGib)
+{
+#ifdef REGAMEDLL_API
+	CSEntity()->m_pevLastInflictor = pevInflictor;
+#else
+	g_pevLastInflictor = pevInflictor;
+#endif
+
+	Killed(pevAttacker, iGib);
+
+#ifdef REGAMEDLL_API
+	CSEntity()->m_pevLastInflictor = nullptr;
+#else
+	g_pevLastInflictor = nullptr;
+#endif
+}
+
+inline entvars_t* CBaseEntity::GetLastInflictor()
+{
+#ifdef REGAMEDLL_API
+	return CSEntity()->m_pevLastInflictor;
+#else
+	return g_pevLastInflictor;
 #endif
 }
 


### PR DESCRIPTION
- Use `m_pevLastInflictor` member from `CSEntity` class to hold entity's last inflictor set in `CBaseMonster::TakeDamage`, instead of a global variable. This will allow inflictor modification/retrieval inside `Killed` function.
- Add inflictor assignation also on `CBaseEntity::TakeDamage` for custom entities.