### PR TITLE
Add member m_iGibDamageThreshold to control GIB damage threshold

### DIFF
--- a/regamedll/dlls/player.cpp
+++ b/regamedll/dlls/player.cpp
@@ -2455,7 +2455,7 @@ void EXT_FUNC CBasePlayer::__API_HOOK(Killed)(entvars_t *pevAttacker, int iGib)
 		HintMessage("#Hint_cannot_play_because_tk", TRUE, TRUE);
 	}
 
-	if ((pev->health < -9000 && iGib != GIB_NEVER) || iGib == GIB_ALWAYS)
+	if (ShouldGibPlayer(iGib))
 	{
 
 #ifndef REGAMEDLL_FIXES

--- a/regamedll/dlls/player.h
+++ b/regamedll/dlls/player.h
@@ -641,6 +641,7 @@ public:
 	bool ShouldToShowAccount(CBasePlayer *pReceiver) const;
 	bool ShouldToShowHealthInfo(CBasePlayer *pReceiver) const;
 	const char *GetKillerWeaponName(entvars_t *pevInflictor, entvars_t *pevKiller) const;
+	bool ShouldGibPlayer(int iGib);
 
 	CBasePlayerItem *GetItemByName(const char *itemName);
 	CBasePlayerItem *GetItemById(WeaponIdType weaponID);

--- a/regamedll/dlls/player.h
+++ b/regamedll/dlls/player.h
@@ -448,7 +448,7 @@ public:
 	edict_t *EntSelectSpawnPoint_OrigFunc();
 	void PlayerDeathThink_OrigFunc();
 	void Observer_Think_OrigFunc();
-	
+
 	CCSPlayer *CSPlayer() const;
 #endif // REGAMEDLL_API
 
@@ -955,7 +955,24 @@ inline bool CBasePlayer::HasTimePassedSinceDeath(float duration) const
 inline CCSPlayer *CBasePlayer::CSPlayer() const {
 	return reinterpret_cast<CCSPlayer *>(this->m_pEntity);
 }
-#endif
+#else // !REGAMEDLL_API
+
+// Determine whether player can be gibbed or not
+inline bool CBasePlayer::ShouldGibPlayer(int iGib)
+{
+	// Always gib the player regardless of incoming damage
+	if (iGib == GIB_ALWAYS)
+		return true;
+
+	// Gib the player if health is below the gib damage threshold
+	if (pev->health < GIB_PLAYER_THRESHOLD && iGib != GIB_NEVER)
+		return true;
+
+	// do not gib the player
+	return false;
+}
+
+#endif // !REGAMEDLL_API
 
 #ifdef REGAMEDLL_FIXES
 

--- a/regamedll/public/regamedll/API/CSPlayer.h
+++ b/regamedll/public/regamedll/API/CSPlayer.h
@@ -214,12 +214,19 @@ inline void CCSPlayer::SetPlayerDominated(CBasePlayer *pPlayer, bool bDominated)
 	m_bPlayerDominated[iPlayerIndex - 1] = bDominated;
 }
 
+#ifdef REGAMEDLL_API
+// Determine whether player can be gibbed or not
 inline bool CBasePlayer::ShouldGibPlayer(int iGib)
 {
-#ifdef REGAMEDLL_API
-	int threshold = CSPlayer()->m_iGibDamageThreshold;
-#else 
-	int threshold = GIB_PLAYER_THRESHOLD;
-#endif
-	return ((pev->health < threshold && iGib != GIB_NEVER) || iGib == GIB_ALWAYS);
+	// Always gib the player regardless of incoming damage
+	if (iGib == GIB_ALWAYS)
+		return true;
+
+	// Gib the player if health is below the gib damage threshold
+	if (pev->health < CSPlayer()->m_iGibDamageThreshold && iGib != GIB_NEVER)
+		return true;
+
+	// do not gib the player
+	return false;
 }
+#endif

--- a/regamedll/public/regamedll/API/CSPlayer.h
+++ b/regamedll/public/regamedll/API/CSPlayer.h
@@ -56,7 +56,8 @@ public:
 		m_flLongJumpHeight(0),
 		m_flLongJumpForce(0),
 		m_flDuckSpeedMultiplier(0),
-		m_iUserID(-1)
+		m_iUserID(-1),
+		m_iGibDamageThreshold(GIB_PLAYER_THRESHOLD)
 	{
 		m_szModel[0] = '\0';
 
@@ -172,6 +173,8 @@ public:
 	void RecordDamage(CBasePlayer *pAttacker, float flDamage, float flFlashDurationTime = -1);
 	int m_iNumKilledByUnanswered[MAX_CLIENTS]; // [0-31] how many unanswered kills this player has been dealt by each other player
 	bool m_bPlayerDominated[MAX_CLIENTS]; // [0-31] array of state per other player whether player is dominating other players
+
+	int m_iGibDamageThreshold; // negative health to reach to gib player
 };
 
 // Inlines
@@ -209,4 +212,14 @@ inline void CCSPlayer::SetPlayerDominated(CBasePlayer *pPlayer, bool bDominated)
 	int iPlayerIndex = pPlayer->entindex();
 	assert(iPlayerIndex >= 0 && iPlayerIndex < MAX_CLIENTS);
 	m_bPlayerDominated[iPlayerIndex - 1] = bDominated;
+}
+
+inline bool CBasePlayer::ShouldGibPlayer(int iGib)
+{
+#ifdef REGAMEDLL_API
+	int threshold = CSPlayer()->m_iGibDamageThreshold;
+#else 
+	int threshold = GIB_PLAYER_THRESHOLD;
+#endif
+	return ((pev->health < threshold && iGib != GIB_NEVER) || iGib == GIB_ALWAYS);
 }

--- a/regamedll/public/regamedll/regamedll_const.h
+++ b/regamedll/public/regamedll/regamedll_const.h
@@ -106,3 +106,4 @@
 #define GIB_NEVER              1 // Never gib, no matter how much death damage is done ( freezing, etc )
 #define GIB_ALWAYS             2 // Always gib ( Houndeye Shock, Barnacle Bite )
 #define GIB_HEALTH_VALUE      -30
+#define GIB_PLAYER_THRESHOLD  -9000


### PR DESCRIPTION
The only way to "naturally" GIB on death for players is reaching -9000 health points. This PR adds a CCSPlayer member that controls that value individually per player. It defaults to -9000.