### PR TITLE
New ConVar: `mp_defuser_allocation`

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ This means that plugins that do binary code analysis (Orpheu for example) probab
 | mp_assist_damage_threshold         | 40      | 0   | 100          | Sets the percentage of damage needed to score an assist. |
 | mp_freezetime_duck                 | 1       | 0   | 1            | Allow players to duck during freezetime.<br/> `0` disabled<br/>`1` enabled |
 | mp_freezetime_jump                 | 1       | 0   | 1            | Allow players to jump during freezetime.<br/> `0` disabled<br/>`1` enabled |
+| mp_defuser_allocation              | 0       | 0   | 2            | Give defuser on player spawn.<br/> `0` disabled<br/>`1` Random players. <br/>`2` All players. |
 </details>
 
 ## How to install zBot for CS 1.6?

--- a/dist/game.cfg
+++ b/dist/game.cfg
@@ -567,3 +567,11 @@ mp_freezetime_duck "1"
 //
 // Default value: "1"
 mp_freezetime_jump "1"
+
+// Give defuser on player spawn
+// 0 - No free defusers (default behavior)
+// 1 - Random players
+// 2 - All players
+//
+// Default value: "0"
+mp_defuser_allocation  "0"

--- a/regamedll/dlls/game.cpp
+++ b/regamedll/dlls/game.cpp
@@ -177,6 +177,7 @@ cvar_t hostages_rescued_ratio = { "mp_hostages_rescued_ratio", "1.0", 0, 1.0f, n
 cvar_t legacy_vehicle_block               = { "mp_legacy_vehicle_block", "1", 0, 0.0f, nullptr };
 
 cvar_t dying_time              = { "mp_dying_time", "3.0", 0, 3.0f, nullptr };
+cvar_t defuser_allocation      = { "mp_defuser_allocation", "0", 0, 0.0f, nullptr };
 
 void GameDLL_Version_f()
 {
@@ -439,6 +440,7 @@ void EXT_FUNC GameDLLInit()
 
 	CVAR_REGISTER(&freezetime_duck);
 	CVAR_REGISTER(&freezetime_jump);
+	CVAR_REGISTER(&defuser_allocation);
 
 	// print version
 	CONSOLE_ECHO("ReGameDLL version: " APP_VERSION "\n");

--- a/regamedll/dlls/game.h
+++ b/regamedll/dlls/game.h
@@ -200,6 +200,7 @@ extern cvar_t deathmsg_flags;
 extern cvar_t assist_damage_threshold;
 extern cvar_t freezetime_duck;
 extern cvar_t freezetime_jump;
+extern cvar_t defuser_allocation;
 
 #endif
 

--- a/regamedll/dlls/gamerules.h
+++ b/regamedll/dlls/gamerules.h
@@ -255,6 +255,13 @@ enum KillRarity
 	KILLRARITY_REVENGE          = 0x100  // Revenge by the killer
 };
 
+enum
+{
+	DEFUSERALLOCATION_NONE      = 0,
+	DEFUSERALLOCATION_RANDOM    = 1,
+	DEFUSERALLOCATION_ALL       = 2,
+};
+
 class CItem;
 
 class CGameRules
@@ -737,6 +744,8 @@ public:
 	void SendDeathMessage(CBaseEntity *pKiller, CBasePlayer *pVictim, CBasePlayer *pAssister, entvars_t *pevInflictor, const char *killerWeaponName, int iDeathMessageFlags, int iRarityOfKill);
 	int GetRarityOfKill(CBaseEntity *pKiller, CBasePlayer *pVictim, CBasePlayer *pAssister, const char *killerWeaponName, bool bFlashAssist);
 	CBasePlayer *CheckAssistsToKill(CBaseEntity *pKiller, CBasePlayer *pVictim, bool &bFlashAssist);
+
+	void GiveDefuserToRandomPlayer();
 
 private:
 	void MarkLivingPlayersOnTeamAsNotReceivingMoneyNextRound(int iTeam);

--- a/regamedll/dlls/player.cpp
+++ b/regamedll/dlls/player.cpp
@@ -10314,6 +10314,9 @@ void EXT_FUNC CBasePlayer::__API_HOOK(OnSpawnEquip)(bool addDefault, bool equipG
 		case ARMOR_VESTHELM: GiveNamedItemEx("item_assaultsuit"); break;
 		}
 	}
+
+	if (NeedsDefuseKit() && (int)defuser_allocation.value == DEFUSERALLOCATION_ALL)
+		GiveNamedItemEx("item_thighpack");
 #endif
 }
 


### PR DESCRIPTION
from: https://totalcsgo.com/commands/mpdefuserallocation

```cpp
// Give defuser on player spawn
// 0 - No free defusers (default behavior)
// 1 - Random players
// 2 - All players
//
// Default value: "0"
mp_defuser_allocation  "0"
```