### PR TITLE
Fix ApplyMultiDamage duplicated call on MultiDamage routine

### DIFF
--- a/regamedll/dlls/weapons.cpp
+++ b/regamedll/dlls/weapons.cpp
@@ -107,8 +107,14 @@ void EXT_FUNC __API_HOOK(AddMultiDamage)(entvars_t *pevInflictor, CBaseEntity *p
 
 	if (pEntity != gMultiDamage.pEntity)
 	{
-		// UNDONE: wrong attacker!
-		ApplyMultiDamage(pevInflictor, pevInflictor);
+#ifdef REGAMEDLL_FIXES
+		if (gMultiDamage.pEntity) // avoid api calls with null default pEntity
+#endif
+		{
+			// UNDONE: wrong attacker!
+			ApplyMultiDamage(pevInflictor, pevInflictor);
+		}
+
 		gMultiDamage.pEntity = pEntity;
 		gMultiDamage.amount = 0;
 	}


### PR DESCRIPTION
This seems redundant but avoids an API call from ApplyMultiDamage at the first AddMultiDamage call since there's no pEntity, forcing a call to this function without success. This expects to straighten subplugin's hooks to work as expected since ApplyMultiDamage should be called at the end of the MultiDamage routine, or when other entity is hit (penetration or shotgun spread).  

In case of a weapon with no penetration (usp, for example) a simple FireBullets3 call will result in:

- ClearMultiDamage (null pEntity)
- TraceAttack pre (null pEntity)
  - AddMultiDamage pre (null pEntity)
    - **ApplyMultiDamage (null pEntity -> no TakeDamage call inside)**
    - _pEntity assigned to a valid entity_
  - AddMultiDamage post (valid pEntity)
- TraceAttack post (valid pEntity)
- ApplyMultiDamage (valid pEntity -> TakeDamage call)