### PR TITLE
API: KickBack function extension

### DIFF
--- a/regamedll/dlls/wpn_shared/wpn_awp.cpp
+++ b/regamedll/dlls/wpn_shared/wpn_awp.cpp
@@ -189,7 +189,11 @@ void CAWP::AWPFire(float flSpread, float flCycleTime, BOOL fUseAutoAim)
 	}
 
 	m_flTimeWeaponIdle = UTIL_WeaponTimeBase() + 2.0f;
+#ifdef REGAMEDLL_ADD
+	KickBack(2.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0);
+#else
 	m_pPlayer->pev->punchangle.x -= 2.0f;
+#endif
 }
 
 void CAWP::Reload()

--- a/regamedll/dlls/wpn_shared/wpn_deagle.cpp
+++ b/regamedll/dlls/wpn_shared/wpn_deagle.cpp
@@ -177,7 +177,11 @@ void CDEAGLE::DEAGLEFire(float flSpread, float flCycleTime, BOOL fUseSemi)
 	}
 
 	m_flTimeWeaponIdle = UTIL_WeaponTimeBase() + 1.8f;
+#ifdef REGAMEDLL_ADD
+	KickBack(2.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0);
+#else
 	m_pPlayer->pev->punchangle.x -= 2;
+#endif
 	ResetPlayerShieldAnim();
 }
 

--- a/regamedll/dlls/wpn_shared/wpn_elite.cpp
+++ b/regamedll/dlls/wpn_shared/wpn_elite.cpp
@@ -200,7 +200,11 @@ void CELITE::ELITEFire(float flSpread, float flCycleTime, BOOL fUseSemi)
 	}
 
 	m_flTimeWeaponIdle = UTIL_WeaponTimeBase() + 2.0f;
+#ifdef REGAMEDLL_ADD
+	KickBack(2.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0);
+#else
 	m_pPlayer->pev->punchangle.x -= 2.0f;
+#endif
 }
 
 void CELITE::Reload()

--- a/regamedll/dlls/wpn_shared/wpn_fiveseven.cpp
+++ b/regamedll/dlls/wpn_shared/wpn_fiveseven.cpp
@@ -176,7 +176,11 @@ void CFiveSeven::FiveSevenFire(float flSpread, float flCycleTime, BOOL fUseSemi)
 	}
 
 	m_flTimeWeaponIdle = UTIL_WeaponTimeBase() + 2.0f;
+#ifdef REGAMEDLL_ADD
+	KickBack(2.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0);
+#else
 	m_pPlayer->pev->punchangle.x -= 2.0f;
+#endif
 	ResetPlayerShieldAnim();
 }
 

--- a/regamedll/dlls/wpn_shared/wpn_g3sg1.cpp
+++ b/regamedll/dlls/wpn_shared/wpn_g3sg1.cpp
@@ -185,8 +185,15 @@ void CG3SG1::G3SG1Fire(float flSpread, float flCycleTime, BOOL fUseAutoAim)
 
 	m_flTimeWeaponIdle = UTIL_WeaponTimeBase() + 1.8f;
 
+#ifdef REGAMEDLL_ADD
+	m_iDirection = 1; // force positive Y addition
+	KickBack(UTIL_SharedRandomFloat(m_pPlayer->random_seed + 4, 0.75, 1.75) + m_pPlayer->pev->punchangle.x * 0.25f, 
+		UTIL_SharedRandomFloat(m_pPlayer->random_seed + 5, -0.75, 0.75), 
+		0.0, 0.0, 0.0, 0.0, 0);
+#else
 	m_pPlayer->pev->punchangle.x -= UTIL_SharedRandomFloat(m_pPlayer->random_seed + 4, 0.75, 1.75) + m_pPlayer->pev->punchangle.x * 0.25f;
 	m_pPlayer->pev->punchangle.y += UTIL_SharedRandomFloat(m_pPlayer->random_seed + 5, -0.75, 0.75);
+#endif
 }
 
 void CG3SG1::Reload()

--- a/regamedll/dlls/wpn_shared/wpn_glock18.cpp
+++ b/regamedll/dlls/wpn_shared/wpn_glock18.cpp
@@ -253,6 +253,9 @@ void CGLOCK18::GLOCK18Fire(float flSpread, float flCycleTime, BOOL bFireBurst)
 		m_flGlock18Shoot = gpGlobals->time + 0.1f;
 	}
 
+#ifdef REGAMEDLL_ADD
+	KickBack(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0); // dummy call, API useful
+#endif
 	ResetPlayerShieldAnim();
 }
 

--- a/regamedll/dlls/wpn_shared/wpn_m3.cpp
+++ b/regamedll/dlls/wpn_shared/wpn_m3.cpp
@@ -167,10 +167,17 @@ void CM3::PrimaryAttack()
 
 	m_fInSpecialReload = 0;
 
+#ifdef REGAMEDLL_ADD
+	if (m_pPlayer->pev->flags & FL_ONGROUND)
+		KickBack(UTIL_SharedRandomLong(m_pPlayer->random_seed + 1, 4, 6), 0.0, 0.0, 0.0, 0.0, 0.0, 0);
+	else
+		KickBack(UTIL_SharedRandomLong(m_pPlayer->random_seed + 1, 8, 11), 0.0, 0.0, 0.0, 0.0, 0.0, 0);
+#else
 	if (m_pPlayer->pev->flags & FL_ONGROUND)
 		m_pPlayer->pev->punchangle.x -= UTIL_SharedRandomLong(m_pPlayer->random_seed + 1, 4, 6);
 	else
 		m_pPlayer->pev->punchangle.x -= UTIL_SharedRandomLong(m_pPlayer->random_seed + 1, 8, 11);
+#endif
 
 	m_pPlayer->m_flEjectBrass = gpGlobals->time + 0.45f;
 }

--- a/regamedll/dlls/wpn_shared/wpn_p228.cpp
+++ b/regamedll/dlls/wpn_shared/wpn_p228.cpp
@@ -176,7 +176,11 @@ void CP228::P228Fire(float flSpread, float flCycleTime, BOOL fUseSemi)
 	}
 
 	m_flTimeWeaponIdle = UTIL_WeaponTimeBase() + 2.0f;
+#ifdef REGAMEDLL_ADD
+	KickBack(2.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0);
+#else
 	m_pPlayer->pev->punchangle.x -= 2;
+#endif
 	ResetPlayerShieldAnim();
 }
 

--- a/regamedll/dlls/wpn_shared/wpn_scout.cpp
+++ b/regamedll/dlls/wpn_shared/wpn_scout.cpp
@@ -181,7 +181,11 @@ void CSCOUT::SCOUTFire(float flSpread, float flCycleTime, BOOL fUseAutoAim)
 	}
 
 	m_flTimeWeaponIdle = UTIL_WeaponTimeBase() + 1.8f;
+#ifdef REGAMEDLL_ADD
+	KickBack(2.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0);
+#else
 	m_pPlayer->pev->punchangle.x -= 2.0f;
+#endif
 }
 
 void CSCOUT::Reload()

--- a/regamedll/dlls/wpn_shared/wpn_sg550.cpp
+++ b/regamedll/dlls/wpn_shared/wpn_sg550.cpp
@@ -188,8 +188,15 @@ void CSG550::SG550Fire(float flSpread, float flCycleTime, BOOL fUseAutoAim)
 
 	m_flTimeWeaponIdle = UTIL_WeaponTimeBase() + 1.8f;
 
+#ifdef REGAMEDLL_ADD
+	m_iDirection = 1; // force positive Y addition
+	KickBack(UTIL_SharedRandomFloat(m_pPlayer->random_seed + 4, 0.75, 1.75) + m_pPlayer->pev->punchangle.x * 0.25, 
+		UTIL_SharedRandomFloat(m_pPlayer->random_seed + 5, -0.75, 0.75), 
+		0.0, 0.0, 0.0, 0.0, 0);
+#else
 	m_pPlayer->pev->punchangle.x -= UTIL_SharedRandomFloat(m_pPlayer->random_seed + 4, 0.75, 1.25) + m_pPlayer->pev->punchangle.x * 0.25;
 	m_pPlayer->pev->punchangle.y += UTIL_SharedRandomFloat(m_pPlayer->random_seed + 5, -0.75, 0.75);
+#endif
 }
 
 void CSG550::Reload()

--- a/regamedll/dlls/wpn_shared/wpn_usp.cpp
+++ b/regamedll/dlls/wpn_shared/wpn_usp.cpp
@@ -239,7 +239,11 @@ void CUSP::USPFire(float flSpread, float flCycleTime, BOOL fUseSemi)
 	}
 
 	m_flTimeWeaponIdle = UTIL_WeaponTimeBase() + 2.0f;
+#ifdef REGAMEDLL_ADD
+	KickBack(2.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0);
+#else
 	m_pPlayer->pev->punchangle.x -= 2.0f;
+#endif
 	ResetPlayerShieldAnim();
 }
 

--- a/regamedll/dlls/wpn_shared/wpn_xm1014.cpp
+++ b/regamedll/dlls/wpn_shared/wpn_xm1014.cpp
@@ -166,10 +166,17 @@ void CXM1014::PrimaryAttack()
 
 	m_fInSpecialReload = 0;
 
+#ifdef REGAMEDLL_ADD
+	if (m_pPlayer->pev->flags & FL_ONGROUND)
+		KickBack(UTIL_SharedRandomLong(m_pPlayer->random_seed + 1, 3, 5), 0.0, 0.0, 0.0, 0.0, 0.0, 0);
+	else
+		KickBack(UTIL_SharedRandomLong(m_pPlayer->random_seed + 1, 7, 10), 0.0, 0.0, 0.0, 0.0, 0.0, 0);
+#else
 	if (m_pPlayer->pev->flags & FL_ONGROUND)
 		m_pPlayer->pev->punchangle.x -= UTIL_SharedRandomLong(m_pPlayer->random_seed + 1, 3, 5);
 	else
 		m_pPlayer->pev->punchangle.x -= UTIL_SharedRandomLong(m_pPlayer->random_seed + 1, 7, 10);
+#endif
 }
 
 void CXM1014::Reload()


### PR DESCRIPTION
This modification extends the usage and hooking of the `CBasePlayerWeapon::KickBack` function which handles recoil control. In summary, the changes made were:

- Punchangle boundary fix: If your punchangles are already in a high value, shooting will clamp punchangle according to the lateral/up max angle value. This PR fixes that by ignoring if already having punchangle in an out-of-boundary value.
- `KickBack` params expanded: You can not force a lateral or up max angle value, or force a direction change probability.

By the mentioned points:
- Now every weapon uses `KickBack`. All other weapons just punches vertically, so `KickBack` needed a readjustment for those basic cases. 
- This is useful for API consumption and event handling, so you can alter/handle every weapon recoil in a simple way.
- There's already a way to use and hook KickBack in reapi, so it will be easy to extend and implement your own custom weapons.
- The following modification maintains a very low probability of altering the original firing behavior, just in very, VERY specific cases (which are highly related to 3rd party plugins).