### PR TITLE
Fix: `ammo`/`weapons` respawn behavior

### DIFF
--- a/regamedll/dlls/ammo.cpp
+++ b/regamedll/dlls/ammo.cpp
@@ -10,7 +10,11 @@ void CBasePlayerAmmo::Spawn()
 
 	SetTouch(&CBasePlayerAmmo::DefaultTouch);
 
-	if (g_pGameRules->IsMultiplayer())
+	if (g_pGameRules->IsMultiplayer()
+#ifdef REGAMEDLL_FIXES
+		&& g_pGameRules->AmmoShouldRespawn(this) == GR_AMMO_RESPAWN_NO
+#endif
+	)
 	{
 		SetThink(&CBaseEntity::SUB_Remove);
 		pev->nextthink = gpGlobals->time + 2.0f;

--- a/regamedll/dlls/multiplay_gamerules.cpp
+++ b/regamedll/dlls/multiplay_gamerules.cpp
@@ -4321,7 +4321,7 @@ int CHalfLifeMultiplay::AmmoShouldRespawn(CBasePlayerAmmo *pAmmo)
 
 float CHalfLifeMultiplay::FlAmmoRespawnTime(CBasePlayerAmmo *pAmmo)
 {
-	return gpGlobals->time + 20.0f;
+	return gpGlobals->time + AMMO_RESPAWN_TIME;
 }
 
 Vector CHalfLifeMultiplay::VecAmmoRespawnSpot(CBasePlayerAmmo *pAmmo)

--- a/regamedll/dlls/weapons.cpp
+++ b/regamedll/dlls/weapons.cpp
@@ -518,7 +518,11 @@ void CBasePlayerItem::Materialize()
 	UTIL_SetOrigin(pev, pev->origin);
 	SetTouch(&CBasePlayerItem::DefaultTouch);
 
-	if (g_pGameRules->IsMultiplayer())
+	if (g_pGameRules->IsMultiplayer()
+#ifdef REGAMEDLL_FIXES
+		&& g_pGameRules->WeaponShouldRespawn(this) == GR_WEAPON_RESPAWN_NO
+#endif
+	)
 	{
 		if (!CanDrop())
 		{

--- a/regamedll/dlls/weapons.cpp
+++ b/regamedll/dlls/weapons.cpp
@@ -559,8 +559,12 @@ void CBasePlayerItem::CheckRespawn()
 {
 	switch (g_pGameRules->WeaponShouldRespawn(this))
 	{
-		case GR_WEAPON_RESPAWN_YES:
+		case GR_WEAPON_RESPAWN_YES: {
+#ifdef REGAMEDLL_FIXES
+			Respawn();
+#endif
 			return;
+		}
 		case GR_WEAPON_RESPAWN_NO:
 			return;
 	}

--- a/regamedll/dlls/weapons.cpp
+++ b/regamedll/dlls/weapons.cpp
@@ -583,6 +583,10 @@ CBaseEntity *CBasePlayerItem::Respawn()
 		// invisible for now
 		pNewWeapon->pev->effects |= EF_NODRAW;
 
+#ifdef REGAMEDLL_ADD
+		pNewWeapon->pev->spawnflags &= ~SF_NORESPAWN;
+#endif
+
 		// no touch
 		pNewWeapon->SetTouch(nullptr);
 		pNewWeapon->SetThink(&CBasePlayerItem::AttemptToMaterialize);


### PR DESCRIPTION
Items that were created without the `SF_NORESPAWN` flag can work normally (like HL: Deathmatch items)
video: https://www.youtube.com/watch?v=TsfiMZ0RuPU

