### PR TITLE
fix mp_kill_filled_spawn

### DIFF
--- a/regamedll/dlls/player.cpp
+++ b/regamedll/dlls/player.cpp
@@ -4310,10 +4310,10 @@ void CBasePlayer::PlayerUse()
 			}
 			// UNDONE: Send different USE codes for ON/OFF.  Cache last ONOFF_USE object to send 'off' if you turn away
 			// BUGBUG This is an "off" use
-			else if ((m_afButtonReleased & IN_USE) 
+			else if ((m_afButtonReleased & IN_USE)
 #ifdef REGAMEDLL_FIXES
 				&& (caps & FCAP_ONOFF_USE))
-#else 
+#else
 				&& (pObject->ObjectCaps() & FCAP_ONOFF_USE))
 #endif
 			{
@@ -5373,11 +5373,6 @@ BOOL IsSpawnPointValid(CBaseEntity *pPlayer, CBaseEntity *pSpot)
 {
 	if (!pSpot->IsTriggered(pPlayer))
 		return FALSE;
-
-#ifdef REGAMEDLL_ADD
-	if (!kill_filled_spawn.value)
-		return TRUE;
-#endif
 
 	CBaseEntity *pEntity = nullptr;
 	while ((pEntity = UTIL_FindEntityInSphere(pEntity, pSpot->pev->origin, MAX_PLAYER_USE_RADIUS)))


### PR DESCRIPTION
By mistake I added an unnecessary and harmful check (from pr #419) commit https://github.com/s1lentq/ReGameDLL_CS/pull/419/commits/d43c4083e73f9d7b99b17ea2fe5817509fab70c5