### PR TITLE
Prevent AddMultiDamage execution with zero/negative damage

### DIFF
--- a/regamedll/dlls/weapons.cpp
+++ b/regamedll/dlls/weapons.cpp
@@ -107,6 +107,11 @@ void EXT_FUNC __API_HOOK(AddMultiDamage)(entvars_t *pevInflictor, CBaseEntity *p
 	if (!pEntity)
 		return;
 
+#ifdef REGAMEDLL_FIXES
+	if (flDamage <= 0.0f) // avoid zero or negative damage TakeDamage
+		return;
+#endif
+
 	gMultiDamage.type |= bitsDamageType;
 
 	if (pEntity != gMultiDamage.hEntity)


### PR DESCRIPTION
## Purpose
The `AddMultiDamage` function can be skipped entirely when no damage will be applied. While some existing cases already avoid calling it with zero damage (e.g. `FireBullets3`, shield hit avoids `TraceAttack`->`AddMultiDamage` calls), there are other scenarios where it is still invoked with a `damage` value of `0` or less (e.g., hitting a player with shotgun pellets while they have an active Shield).

These unnecessary calls not only waste processing but can also have unintended side effects for APIs implemented by developers that rely on `TakeDamage` being called only when damage is actually applied. This PR ensures that the function only executes when `flDamage > 0`.

## Approach
Added a simple check at the start of `AddMultiDamage` to immediately return if the `flDamage` parameter is `0` or less.